### PR TITLE
Changed error message from 'data' to 'data-file'

### DIFF
--- a/example-get-started/code/src/prepare.py
+++ b/example-get-started/code/src/prepare.py
@@ -8,7 +8,7 @@ import errno
 
 if len(sys.argv) != 2:
     sys.stderr.write("Arguments error. Usage:\n")
-    sys.stderr.write("\tpython prepare.py data\n")
+    sys.stderr.write("\tpython prepare.py data-file\n")
     sys.exit(1)
 
 # Test data set split ratio


### PR DESCRIPTION
In https://github.com/iterative/example-get-started/blob/master/src/prepare.py, the error should specify data-file instead of just data, as data is a directory in the same tutorial
It will lead to clearer explanation, and is also in reference to iterative/dataset-registry#6