### PR TITLE
Update example-get-started readme

### DIFF
--- a/example-get-started/code/README.md
+++ b/example-get-started/code/README.md
@@ -33,10 +33,9 @@ $ source .env/bin/activate
 $ pip install -r src/requirements.txt
 ```
 
-> This instruction assumes that DVC is already installed, as it is frequently 
-used as a global tool like Git. If DVC is not installed, see the 
-[DVC installation guide](https://dvc.org/doc/install) on how to install DVC.
-
+> This instruction assumes that DVC is already installed, as it is frequently
+> used as a global tool like Git. If DVC is not installed, see the
+> [DVC installation guide](https://dvc.org/doc/install) on how to install DVC.
 
 This DVC project comes with a preconfigured DVC
 [remote storage](https://dvc.org/doc/commands-reference/remote) that holds raw

--- a/example-get-started/code/README.md
+++ b/example-get-started/code/README.md
@@ -33,17 +33,15 @@ $ source .env/bin/activate
 $ pip install -r src/requirements.txt
 ```
 
-Note that dvc is not installed by the requirements file, 
-as it is supposed to be used as a global tool like git. If dvc is not installed,
-use the following command to install it:
-```console
-$ pip install dvc
-```
+> This instruction assumes that DVC is already installed, as it is frequently 
+used as a global tool like Git. If DVC is not installed, see the 
+[DVC installation guide](https://dvc.org/doc/install) on how to install DVC.
+
 
 This DVC project comes with a preconfigured DVC
 [remote storage](https://dvc.org/doc/commands-reference/remote) that holds raw
 data (input), intermediate, and final results that are produced. This is a
-read-only HTTP remote. 
+read-only HTTP remote.
 
 ```console
 $ dvc remote list

--- a/example-get-started/code/README.md
+++ b/example-get-started/code/README.md
@@ -33,10 +33,17 @@ $ source .env/bin/activate
 $ pip install -r src/requirements.txt
 ```
 
+Note that dvc is not installed by the requirements file, 
+as it is supposed to be used as a global tool like git. If dvc is not installed,
+use the following command to install it:
+```console
+$ pip install dvc
+```
+
 This DVC project comes with a preconfigured DVC
 [remote storage](https://dvc.org/doc/commands-reference/remote) that holds raw
 data (input), intermediate, and final results that are produced. This is a
-read-only HTTP remote.
+read-only HTTP remote. 
 
 ```console
 $ dvc remote list


### PR DESCRIPTION
The README.md assumes that the user which is just getting started with dvc, already has dvc installed.
By adding this note the user will know that it can install dvc if it is missing.