### PR TITLE
push experiments to remote

### DIFF
--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -171,6 +171,7 @@ cd build/example-get-started
 git remote add origin git@github.com:iterative/example-get-started.git
 git push --force origin master
 git push --force origin --tags
+dvc exp list --all --names-only | xargs -n 1 dvc exp push origin
 cd ../..
 
 You may remove the generated repo with:


### PR DESCRIPTION
Adds remote experiments to example-get-started repo.

See https://github.com/iterative/dvc.org/pull/2259#discussion_r596120116.