### PR TITLE
Modified to have delays between commits and custom author and email

### DIFF
--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -20,10 +20,11 @@ TOTAL_TAGS=15
 STEP_TIME=100000
 BEGIN_TIME=$(( $(date +%s) - ( ${TOTAL_TAGS} * ${STEP_TIME}) ))
 TAG_TIME=${BEGIN_TIME}
-export GIT_AUTHOR_NAME="Dee Vee"
-export GIT_AUTHOR_EMAIL="dee@dvc.org"
-export GIT_COMMITTER_NAME="Dee Vee"
-export GIT_COMMITTER_EMAIL="dee@dvc.org"
+
+export GIT_AUTHOR_NAME="Olivaw Owlet"
+export GIT_AUTHOR_EMAIL="64868532+iterative-olivaw@users.noreply.github.com"
+export GIT_COMMITTER_NAME="Olivaw Owlet"
+export GIT_COMMITTER_EMAIL="64868532+iterative-olivaw@users.noreply.github.com"
 
 mkdir -p $REPO_PATH
 pushd $REPO_PATH

--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -43,6 +43,8 @@ TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit -m  "Initialize Git repository"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "0-git-init" -m "Git initialized."
 
 dvc init
@@ -50,6 +52,8 @@ TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit -m "Initialize DVC project"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "1-dvc-init" -m "DVC initialized."
 
 mkdir data
@@ -62,6 +66,8 @@ TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -m "Add raw data"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "2-track-data" -m "Data file added."
 
 # Remote active on this env only, for writing to HTTP redirect below.
@@ -73,6 +79,8 @@ TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -m "Configure default remote"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "3-config-remote" -m "Read-only remote storage configured."
 dvc push
 
@@ -86,6 +94,8 @@ GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -m "Import raw data (overwrite)"
 dvc push
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "4-import-data" -m "Data file overwritten with an import."
 
 wget https://code.dvc.org/get-started/code.zip
@@ -97,6 +107,8 @@ TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -m "Add source code files to repo"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "5-source-code" -m "Source code added."
 
 
@@ -111,6 +123,8 @@ GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -m "Create data preparation stage"
 dvc push
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "6-prepare-stage" -m "First pipeline stage (data preparation) created."
 
 
@@ -135,6 +149,8 @@ GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -m "Create ML pipeline stages"
 dvc push
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "7-ml-pipeline" -m "ML pipeline created."
 
 dvc run -n evaluate \
@@ -153,7 +169,11 @@ GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -m "Create evaluation stage"
 dvc push
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "baseline-experiment" -m "Baseline experiment evaluation"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "8-evaluation" -m "Baseline evaluation stage created."
 
 sed -e "s/max_features: 500/max_features: 1500/" -i params.yaml
@@ -165,6 +185,8 @@ TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -am "Reproduce model using bigrams"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "9-bigrams-model" -m "Model retrained using bigrams."
 
 dvc repro evaluate
@@ -173,7 +195,11 @@ TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -am "Evaluate bigrams model"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "bigrams-experiment" -m "Bigrams experiment evaluation"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "10-bigrams-experiment" -m "Evaluated bigrams model."
 dvc push
 
@@ -190,7 +216,11 @@ TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -am "Run experiments tuning random forest params"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "random-forest-experiments" -m "Run experiments to tune random forest params"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_COMMITTER_DATE=${TAG_TIME} \
 git tag -a "11-random-forest-experiments" -m "Tuned random forest classifier."
 dvc push
 

--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -159,8 +159,8 @@ git tag -a "baseline-experiment" -m "Baseline experiment evaluation"
 git tag -a "8-evaluation" -m "Baseline evaluation stage created."
 TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
-sed -e "s/max_features: 500/max_features: 1500/" -i "" params.yaml
-sed -e "s/ngrams: 1/ngrams: 2/" -i "" params.yaml
+sed -e "s/max_features: 500/max_features: 1500/" -i params.yaml
+sed -e "s/ngrams: 1/ngrams: 2/" -i params.yaml
 
 
 dvc repro train

--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # See https://dvc.org/doc/tutorials/get-started
 
 # Setup script env:
@@ -16,6 +16,13 @@ if [ -d "$REPO_PATH" ]; then
     exit 1
 fi
 
+TOTAL_TAGS=15
+STEP_TIME=100000
+BEGIN_TIME=$(( $(date +%s) - ( ${TOTAL_TAGS} * ${STEP_TIME}) ))
+TAG_TIME=${BEGIN_TIME}
+AUTHOR="Dee Vee"
+EMAIL="dee@dvc.org"
+
 mkdir -p $REPO_PATH
 pushd $REPO_PATH
 
@@ -30,51 +37,71 @@ pip install "git+https://github.com/iterative/dvc#egg=dvc[all]"
 git init
 cp $HERE/code/README.md .
 git add .
-git commit -m  "Initialize Git repository"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -m  "Initialize Git repository"
 git tag -a "0-git-init" -m "Git initialized."
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 
 dvc init
-git commit -m "Initialize DVC project"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -m "Initialize DVC project"
 git tag -a "1-dvc-init" -m "DVC initialized."
-
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 mkdir data
 dvc get https://github.com/iterative/dataset-registry \
         get-started/data.xml -o data/data.xml
 dvc add data/data.xml --desc "Initial XML StackOverflow dataset (raw data)"
 git add data/.gitignore data/data.xml.dvc
-git commit -m "Add raw data"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -m "Add raw data"
 git tag -a "2-track-data" -m "Data file added."
-
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 # Remote active on this env only, for writing to HTTP redirect below.
 dvc remote add -d --local storage s3://dvc-public/remote/get-started
 # Actual remote for generated project (read-only). Redirect of S3 bucket above.
 dvc remote add -d storage https://remote.dvc.org/get-started
 git add .
-git commit -m "Configure default remote"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -m "Configure default remote"
 git tag -a "3-config-remote" -m "Read-only remote storage configured."
 dvc push
-
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 rm data/data.xml data/data.xml.dvc
 dvc import https://github.com/iterative/dataset-registry \
            get-started/data.xml -o data/data.xml \
            --desc "Imported raw data (tracks source updates)"
 git add data/data.xml.dvc
-git commit -m "Import raw data (overwrite)"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -m "Import raw data (overwrite)"
 dvc push
 git tag -a "4-import-data" -m "Data file overwritten with an import."
-
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 wget https://code.dvc.org/get-started/code.zip
 unzip code.zip
 rm -f code.zip
 pip install -r src/requirements.txt
 git add .
-git commit -m "Add source code files to repo"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -m "Add source code files to repo"
 git tag -a "5-source-code" -m "Source code added."
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 
 dvc run -n prepare \
@@ -83,9 +110,13 @@ dvc run -n prepare \
         -o data/prepared \
         python src/prepare.py data/data.xml
 git add data/.gitignore dvc.yaml dvc.lock
-git commit -m "Create data preparation stage"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -m "Create data preparation stage"
 dvc push
 git tag -a "6-prepare-stage" -m "First pipeline stage (data preparation) created."
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 
 dvc run -n featurize \
@@ -102,10 +133,13 @@ dvc run -n train \
         -o model.pkl \
         python src/train.py data/features model.pkl
 git add .gitignore dvc.yaml dvc.lock
-git commit -m "Create ML pipeline stages"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -m "Create ML pipeline stages"
 dvc push
 git tag -a "7-ml-pipeline" -m "ML pipeline created."
-
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 dvc run -n evaluate \
         -d src/evaluate.py -d model.pkl -d data/features \
@@ -116,27 +150,36 @@ dvc run -n evaluate \
 dvc plots modify prc.json -x recall -y precision
 dvc plots modify roc.json -x fpr -y tpr
 git add .gitignore dvc.yaml dvc.lock prc.json roc.json scores.json
-git commit -m "Create evaluation stage"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -m "Create evaluation stage"
 dvc push
 git tag -a "baseline-experiment" -m "Baseline experiment evaluation"
 git tag -a "8-evaluation" -m "Baseline evaluation stage created."
-
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 sed -e "s/max_features: 500/max_features: 1500/" -i "" params.yaml
 sed -e "s/ngrams: 1/ngrams: 2/" -i "" params.yaml
 
 
 dvc repro train
-git commit -am "Reproduce model using bigrams"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -am "Reproduce model using bigrams"
 git tag -a "9-bigrams-model" -m "Model retrained using bigrams."
-
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 dvc repro evaluate
-git commit -am "Evaluate bigrams model"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -am "Evaluate bigrams model"
 git tag -a "bigrams-experiment" -m "Bigrams experiment evaluation"
 git tag -a "10-bigrams-experiment" -m "Evaluated bigrams model."
 dvc push
-
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 dvc exp run --set-param featurize.max_features=3000
 dvc exp run --queue --set-param train.min_split=8
@@ -147,11 +190,14 @@ dvc exp run --queue --set-param train.min_split=64 --set-param train.n_est=100
 dvc exp run --run-all -j 2
 # Apply best experiment.
 dvc exp apply $(dvc exp show --no-pager --sort-by avg_prec | tail -n 2 | head -n 1 | grep -o 'exp-\w*')
-git commit -am "Run experiments tuning random forest params"
+GIT_AUTHOR_DATE=${TAG_TIME} \
+GIT_AUTHOR_NAME="${AUTHOR}" \
+GIT_AUTHOR_EMAIL=${EMAIL} \
+git commit --date=${TAG_TIME} -am "Run experiments tuning random forest params"
 git tag -a "random-forest-experiments" -m "Run experiments to tune random forest params"
 git tag -a "11-random-forest-experiments" -m "Tuned random forest classifier."
 dvc push
-
+TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
 
 popd
 


### PR DESCRIPTION
I can't test this on my laptop for some reason but should work to update timestamp, author, and email of commits. 

For github.com/iterative/example-get-started/ repository:

* Starts 15 * 100,000 seconds before now and puts 100.000 seconds between each tag
* Sets author/committer to "Olivaw Owlet"
* Sets email to `64868532+iterative-olivaw@users.noreply.github.com`

