### PR TITLE
initial CML workflow

### DIFF
--- a/example-get-started/code/.github/workflows/cml.yaml
+++ b/example-get-started/code/.github/workflows/cml.yaml
@@ -1,0 +1,19 @@
+name: CML Report
+on: [push, pull_request]
+jobs:
+  run:
+    runs-on: [ubuntu-latest]
+    container: docker://dvcorg/cml:0-dvc2-base1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Generate metrics report
+        env:
+          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # generate plots
+          dvc plots show --show-vega prc.json > vega.json
+          vl2svg vega.json prc.svg
+
+          echo "## Metrics report" > report.md
+          cml-publish prc.svg --title "Precision & Recall" --md >> report.md
+          cml-send-comment report.md

--- a/example-get-started/code/.github/workflows/cml.yaml
+++ b/example-get-started/code/.github/workflows/cml.yaml
@@ -1,19 +1,27 @@
 name: CML Report
-on: [push, pull_request]
+on: push
 jobs:
   run:
     runs-on: [ubuntu-latest]
     container: docker://dvcorg/cml:0-dvc2-base1
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Generate metrics report
         env:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # generate plots
-          dvc plots show --show-vega prc.json > vega.json
-          vl2svg vega.json prc.svg
+          echo "# CML Report" > report.md
 
-          echo "## Metrics report" > report.md
+          echo "## Plots" >> report.md
+          dvc plots diff bigrams-experiment workspace \
+            --show-vega --targets prc.json > vega.json
+          vl2svg vega.json prc.svg
           cml-publish prc.svg --title "Precision & Recall" --md >> report.md
+
+          echo "## Metrics" >> report.md
+          echo "### bigrams-experiment → workspace" >> report.md
+          dvc metrics diff bigrams-experiment --show-md >> report.md
+
           cml-send-comment report.md

--- a/example-get-started/deploy.sh
+++ b/example-get-started/deploy.sh
@@ -12,7 +12,7 @@ rm -rf $TEST_DIR
 mkdir $TEST_DIR
 
 pushd $PACKAGE_DIR
-zip -r $PACKAGE params.yaml src/*
+zip -r $PACKAGE params.yaml src/* .github/*
 popd
 
 # Requires AWS CLI and write access to `s3://dvc-public/code/get-started/`.

--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -214,6 +214,7 @@ dvc exp run --run-all -j 2
 # Apply best experiment.
 dvc exp apply $(dvc exp show --no-pager --sort-by avg_prec | tail -n 2 | head -n 1 | grep -o 'exp-\w*')
 TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
+git add .github/workflows/cml.yaml
 GIT_AUTHOR_DATE=${TAG_TIME} \
 GIT_COMMITTER_DATE=${TAG_TIME} \
 git commit  -am "Run experiments tuning random forest params"
@@ -257,4 +258,3 @@ You may remove the generated repo with:
 rm -fR build
 
 `"
-


### PR DESCRIPTION
Uses:

- [x] latest non-GPU CML docker image (ubuntu20.04, py3.8, dvc2)
- [x] `dvc plots diff`
- [x] `dvc metrics diff`
- [x] `cml-publish`
- [x] `cml-send-comment`
- [x] report is posted twice here because this workflow currently runs on both PRs and pushes. Maybe just run on push?
- [ ] larger dataset branch?

It also runs on each commit which may be annoying (https://github.com/iterative/cml/issues/512).