### PR TITLE
example-dvc-experiments: cp .gitattributes

### DIFF
--- a/example-dvc-experiments/generate.bash
+++ b/example-dvc-experiments/generate.bash
@@ -80,6 +80,7 @@ pip install 'dvc[all]'
 git init
 git checkout -b main
 cp $HERE/code/README.md "${REPO_PATH}"
+cp $HERE/.gitattributes "${REPO_PATH}"
 cp $HERE/code/.gitignore "${REPO_PATH}"
 tag_tick
 git add .gitignore README.md


### PR DESCRIPTION
This provides syntax-highlighting support for .dvc and dvc.lock files in the Github.

See #72 and #73.