### PR TITLE
marks model.h5 as a cached output

### DIFF
--- a/example-dvc-experiments/code/src/train.py
+++ b/example-dvc-experiments/code/src/train.py
@@ -1,7 +1,9 @@
+import os
+# Set tensorflow logging to minimum
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'  # or any {'0', '1', '2'}
 import tensorflow as tf
 import numpy as np
 from util import load_params, read_labeled_images
-import os
 import json
 
 INPUT_DIR = "data/images"
@@ -77,10 +79,10 @@ def main():
     assert training_images.shape[0] + testing_images.shape[0] == 70000
     assert training_labels.shape[0] + testing_labels.shape[0] == 70000
 
-    print(f"Training Dataset Shape: {training_images.shape}")
-    print(f"Testing Dataset Shape: {testing_images.shape}")
-    print(f"Training Labels: {training_labels}")
-    print(f"Testing Labels: {testing_labels}")
+    # print(f"Training Dataset Shape: {training_images.shape}")
+    # print(f"Testing Dataset Shape: {testing_images.shape}")
+    # print(f"Training Labels: {training_labels}")
+    # print(f"Testing Labels: {testing_labels}")
 
     training_images = normalize(training_images)
     testing_images = normalize(testing_images)

--- a/example-dvc-experiments/code/src/util.py
+++ b/example-dvc-experiments/code/src/util.py
@@ -5,47 +5,48 @@ from imageio import imread
 
 
 def get_images_from_directory(directory):
-    image_file_extensions = ['.png', '.jpg', '.bmp']
+    image_file_extensions = [".png", ".jpg", ".bmp"]
     images = []
     # we assume the images are 28x28 grayscale
     shape_0, shape_1 = 28, 28
     for f in os.listdir(directory):
         if os.path.splitext(f)[1] in image_file_extensions:
             current_img = imread(os.path.join(directory, f))
-            if (len(current_img.shape) != 2 or current_img.shape[0] != shape_0 or current_img.shape[1] != shape_1):
+            if (
+                len(current_img.shape) != 2
+                or current_img.shape[0] != shape_0
+                or current_img.shape[1] != shape_1
+            ):
                 raise Exception("Works with 28x28 grayscale images")
             images.append(current_img)
-    image_array = np.ndarray(
-        shape=(len(images), shape_0, shape_1), dtype='uint8')
+    image_array = np.ndarray(shape=(len(images), shape_0, shape_1), dtype="uint8")
     for i, img in enumerate(images):
         image_array[i] = img
-    print(image_array.shape)
     return image_array
 
 
 def read_labeled_images(directory):
     """The structure of the directory should be like:
-.
-├── 0
-├── 1
-├── 2
-├── 3
-├── 4
-├── 5
-├── 6
-├── 7
-├── 8
-└── 9
+    .
+    ├── 0
+    ├── 1
+    ├── 2
+    ├── 3
+    ├── 4
+    ├── 5
+    ├── 6
+    ├── 7
+    ├── 8
+    └── 9
 
-    and contain PNG images in each directory.
-"""
+        and contain PNG images in each directory."""
     shape_0, shape_1 = 28, 28
-    label_array = np.ndarray(shape=0, dtype='uint8')
-    image_array = np.ndarray(shape=(0, shape_0, shape_1), dtype='uint8')
+    label_array = np.ndarray(shape=0, dtype="uint8")
+    image_array = np.ndarray(shape=(0, shape_0, shape_1), dtype="uint8")
     for label in range(0, 10):
         images_dir = f"{directory}/{label}"
         images = get_images_from_directory(images_dir)
-        labels = np.ones(shape=(images.shape[0]), dtype='uint8') * label
+        labels = np.ones(shape=(images.shape[0]), dtype="uint8") * label
         image_array = np.concatenate((image_array, images), axis=0)
         label_array = np.concatenate((label_array, labels), axis=0)
 
@@ -62,7 +63,7 @@ def load_params():
 
 def load_npz_data(filename):
     npzfile = np.load(filename)
-    return (npzfile['images'], npzfile['labels'])
+    return (npzfile["images"], npzfile["labels"])
 
 
 def shuffle_in_parallel(seed, array1, array2):

--- a/example-dvc-experiments/generate.bash
+++ b/example-dvc-experiments/generate.bash
@@ -57,7 +57,7 @@ add_main_pipeline() {
                 -d src/train.py \
                 -p model.conv_units \
                 -p train.epochs \
-                --outs-no-cache models/model.h5 \
+                --outs models/model.h5 \
                 --plots-no-cache logs.csv \
                 --metrics-no-cache metrics.json \
                 python3 src/train.py

--- a/example-dvc-experiments/generate.bash
+++ b/example-dvc-experiments/generate.bash
@@ -127,17 +127,6 @@ git tag "configured-remote"
 
 git tag "get-started"
 
-# We added the following to the pipeline
-# pushd data
-# tar -xvzf images.tar.gz
-# popd
-# tag_tick
-# dvc add data/images
-# git add data/images.dvc data/.gitignore
-# git commit -m "Added Fashion-MNIST images directory"
-# git tag -a "extracted-images" -m "Fashion-MNIST data directory added."
-#
-
 dvc exp run
 tag_tick
 git add models/.gitignore data/.gitignore dvc.lock logs.csv metrics.json

--- a/example-dvc-experiments/generate.bash
+++ b/example-dvc-experiments/generate.bash
@@ -62,8 +62,6 @@ add_main_pipeline() {
                 --metrics-no-cache metrics.json \
                 python3 src/train.py
 
-    echo "model.h5" >> models/.gitignore
-
 }
 
 export REPO_PATH="${REPO_ROOT}/${PROJECT_NAME}"
@@ -142,7 +140,6 @@ git tag "get-started"
 
 dvc exp run
 tag_tick
-echo "model.h5" >> models/.gitignore
 git add models/.gitignore data/.gitignore dvc.lock logs.csv metrics.json
 git commit -m "Baseline experiment run"
 git tag "baseline-experiment"

--- a/example-dvc-experiments/generate.bash
+++ b/example-dvc-experiments/generate.bash
@@ -127,7 +127,8 @@ git tag "configured-remote"
 
 git tag "get-started"
 
-dvc exp run
+# dvc exp run is not suitable for the first run due to missing file warnings
+dvc repro
 tag_tick
 git add models/.gitignore data/.gitignore dvc.lock logs.csv metrics.json
 git commit -m "Baseline experiment run"
@@ -172,7 +173,9 @@ git ls-remote origin 'refs/exps/*' | cut -f 2 | while read exppath ; do
    git push -d origin "\${exppath}"
 done
 
-git push --force origin --all --follow-tags
+git push --force origin --all
+# We use lightweight tags so --follow-tags don't work
+git push --force origin --tags
 dvc exp list --all --names-only | xargs -n 1 dvc exp push origin
 popd
 EOF

--- a/example-dvc-experiments/generate.bash
+++ b/example-dvc-experiments/generate.bash
@@ -5,7 +5,7 @@ set -veux
 HERE="$( cd "$(dirname "$0")" ; pwd -P )"
 export HERE
 PROJECT_NAME="example-dvc-experiments"
-REPO_NAME="$(date +%F-%H-%M-%S)"
+REPO_NAME="$(git rev-parse --short HEAD)-$(date +%F-%H-%M-%S)"
 export REPO_NAME
 
 export REPO_ROOT="${HERE}/build/${REPO_NAME}"


### PR DESCRIPTION
This fixes #86 

- It shows the following warning when pushing the generated repo. It may need further tweaks. 

![image](https://user-images.githubusercontent.com/476310/132339807-48184ca5-c241-462d-a031-d53042b8cb3f.png)
