### PR TITLE
get-started: more plots, dvclive, better dataset

### DIFF
--- a/example-get-started/analyze.py
+++ b/example-get-started/analyze.py
@@ -1,0 +1,42 @@
+import io
+import os
+import random
+import re
+import sys
+import xml.etree.ElementTree
+
+
+if len(sys.argv) != 3:
+    sys.stderr.write("Arguments error. Usage:\n")
+    sys.stderr.write("\tpython analyze.py data-file output-file\n")
+    sys.exit(1)
+
+target = 40000
+split = 0.3
+
+
+def lines_matched_test(fd, test):
+    for line in fd:
+        try:
+            attr = xml.etree.ElementTree.fromstring(line).attrib
+            if test(attr.get("Tags", "")):
+                yield line
+        except Exception as ex:
+            sys.stderr.write(f"Skipping the broken line: {ex}\n")
+    
+
+def process_posts(fd_in, fd_not, fd_out):
+    count = 0
+    in_lines = lines_matched_test(fd_in, lambda x: "<r>" in x)
+    not_lines = lines_matched_test(fd_not, lambda x: "<r>" not in x)
+    while count < target:
+        line = next(not_lines) if random.random() > split else next(in_lines)
+        fd_out.write(line)
+        count += 1
+
+
+with io.open(sys.argv[1], encoding="utf8") as fd_in:
+    with io.open(sys.argv[1], encoding="utf8") as fd_not:
+        with io.open(sys.argv[2], "w", encoding="utf8") as fd_out:
+            process_posts(fd_in, fd_not, fd_out)
+

--- a/example-get-started/code/.github/workflows/cml.yaml
+++ b/example-get-started/code/.github/workflows/cml.yaml
@@ -23,9 +23,14 @@ jobs:
           echo "# CML Report" > report.md
           echo "## Plots" >> report.md
           dvc plots diff $PREVIOUS_REF workspace \
-            --show-vega --targets prc.json > vega.json
+            --show-vega --targets evaluation/plots/precision_recall.json > vega.json
           vl2svg vega.json prc.svg
           cml publish prc.svg --title "Precision & Recall" --md >> report.md
+
+          dvc plots show \
+            --show-vega evaluation/plots/predictions.json > vega.json
+          vl2svg vega.json confusion.svg
+          cml publish confusion.svg --title "Confusion Matrix" --md >> report.md
 
           echo "## Metrics" >> report.md
           echo "### $PREVIOUS_REF → workspace" >> report.md

--- a/example-get-started/code/README.md
+++ b/example-get-started/code/README.md
@@ -8,8 +8,8 @@ introduction into basic DVC concepts.
 
 The project is a natural language processing (NLP) binary classifier problem of
 predicting tags for a given StackOverflow question. For example, we want one
-classifier which can predict a post that is about the Python language by tagging
-it `python`.
+classifier which can predict a post that is about the R language by tagging it
+`R`.
 
 🐛 Please report any issues found in this project here -
 [example-repos-dev](https://github.com/iterative/example-repos-dev).
@@ -160,3 +160,4 @@ $ tree
     ├── requirements.txt  # <-- Python dependencies needed in the project
     └── train.py
 ```
+

--- a/example-get-started/code/params.yaml
+++ b/example-get-started/code/params.yaml
@@ -3,10 +3,11 @@ prepare:
   seed: 20170428
 
 featurize:
-  max_features: 500
+  max_features: 100
   ngrams: 1
 
 train:
   seed: 20170428
   n_est: 50
   min_split: 2
+

--- a/example-get-started/code/src/evaluate.py
+++ b/example-get-started/code/src/evaluate.py
@@ -4,24 +4,28 @@ import os
 import pickle
 import sys
 
-import sklearn.metrics as metrics
+import pandas as pd
+from sklearn import metrics
+from sklearn import tree
+from dvclive import Live
+from matplotlib import pyplot as plt
 
-if len(sys.argv) != 6:
+
+live = Live("evaluation")
+
+if len(sys.argv) != 3:
     sys.stderr.write("Arguments error. Usage:\n")
-    sys.stderr.write("\tpython evaluate.py model features scores prc roc\n")
+    sys.stderr.write("\tpython evaluate.py model features\n")
     sys.exit(1)
 
 model_file = sys.argv[1]
 matrix_file = os.path.join(sys.argv[2], "test.pkl")
-scores_file = sys.argv[3]
-prc_file = sys.argv[4]
-roc_file = sys.argv[5]
 
 with open(model_file, "rb") as fd:
     model = pickle.load(fd)
 
 with open(matrix_file, "rb") as fd:
-    matrix = pickle.load(fd)
+    matrix, feature_names = pickle.load(fd)
 
 labels = matrix[:, 1].toarray()
 x = matrix[:, 2:]
@@ -29,20 +33,19 @@ x = matrix[:, 2:]
 predictions_by_class = model.predict_proba(x)
 predictions = predictions_by_class[:, 1]
 
-precision, recall, prc_thresholds = metrics.precision_recall_curve(labels, predictions)
-fpr, tpr, roc_thresholds = metrics.roc_curve(labels, predictions)
+# Use dvclive to log a few simple plots ...
+live.log_plot("roc", labels, predictions)
+live.log("avg_prec", metrics.average_precision_score(labels, predictions))
+live.log("roc_auc", metrics.roc_auc_score(labels, predictions))
 
-avg_prec = metrics.average_precision_score(labels, predictions)
-roc_auc = metrics.roc_auc_score(labels, predictions)
-
-with open(scores_file, "w") as fd:
-    json.dump({"avg_prec": avg_prec, "roc_auc": roc_auc}, fd, indent=4)
-
+# ... but actually it can be done with dumping data points into a file:
 # ROC has a drop_intermediate arg that reduces the number of points.
 # https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_curve.html#sklearn.metrics.roc_curve.
 # PRC lacks this arg, so we manually reduce to 1000 points as a rough estimate.
+precision, recall, prc_thresholds = metrics.precision_recall_curve(labels, predictions)
 nth_point = math.ceil(len(prc_thresholds) / 1000)
 prc_points = list(zip(precision, recall, prc_thresholds))[::nth_point]
+prc_file = "evaluation/plots/precision_recall.json"
 with open(prc_file, "w") as fd:
     json.dump(
         {
@@ -55,14 +58,21 @@ with open(prc_file, "w") as fd:
         indent=4,
     )
 
-with open(roc_file, "w") as fd:
-    json.dump(
-        {
-            "roc": [
-                {"fpr": fp, "tpr": tp, "threshold": t}
-                for fp, tp, t in zip(fpr, tpr, roc_thresholds)
-            ]
-        },
-        fd,
-        indent=4,
-    )
+
+# ... confusion matrix plot
+predictions = [{
+                "actual": int(actual),
+                "predicted": 1 if predicted > 0.5 else 0
+               } for actual, predicted in zip(labels, predictions)]
+with open("evaluation/plots/predictions.json", "w") as f:
+    json.dump(predictions, f)
+
+# ... and finally, we can dump an image, it's also supported:
+fig, axes = plt.subplots(dpi=800)
+fig.subplots_adjust(bottom=0.2, top=0.95)
+importances = model.feature_importances_
+forest_importances = pd.Series(importances, index=feature_names).nlargest(n=30)
+axes.set_ylabel("Mean decrease in impurity")
+forest_importances.plot.bar(ax=axes)
+fig.savefig('evaluation/importance.png')
+

--- a/example-get-started/code/src/featurization.py
+++ b/example-get-started/code/src/featurization.py
@@ -38,7 +38,7 @@ def get_df(data):
     return df
 
 
-def save_matrix(df, matrix, output):
+def save_matrix(df, matrix, names, output):
     id_matrix = sparse.csr_matrix(df.id.astype(np.int64)).T
     label_matrix = sparse.csr_matrix(df.label.astype(np.int64)).T
 
@@ -48,7 +48,7 @@ def save_matrix(df, matrix, output):
     sys.stderr.write(msg.format(output, result.shape, result.dtype))
 
     with open(output, "wb") as fd:
-        pickle.dump(result, fd)
+        pickle.dump((result, names), fd)
     pass
 
 
@@ -64,11 +64,12 @@ bag_of_words = CountVectorizer(
 
 bag_of_words.fit(train_words)
 train_words_binary_matrix = bag_of_words.transform(train_words)
+feature_names = bag_of_words.get_feature_names_out()
 tfidf = TfidfTransformer(smooth_idf=False)
 tfidf.fit(train_words_binary_matrix)
 train_words_tfidf_matrix = tfidf.transform(train_words_binary_matrix)
 
-save_matrix(df_train, train_words_tfidf_matrix, train_output)
+save_matrix(df_train, train_words_tfidf_matrix, feature_names, train_output)
 
 # Generate test feature matrix
 df_test = get_df(test_input)
@@ -76,4 +77,5 @@ test_words = np.array(df_test.text.str.lower().values.astype("U"))
 test_words_binary_matrix = bag_of_words.transform(test_words)
 test_words_tfidf_matrix = tfidf.transform(test_words_binary_matrix)
 
-save_matrix(df_test, test_words_tfidf_matrix, test_output)
+save_matrix(df_test, test_words_tfidf_matrix, feature_names, test_output)
+

--- a/example-get-started/code/src/prepare.py
+++ b/example-get-started/code/src/prepare.py
@@ -48,4 +48,5 @@ os.makedirs(os.path.join("data", "prepared"), exist_ok=True)
 with io.open(input, encoding="utf8") as fd_in:
     with io.open(output_train, "w", encoding="utf8") as fd_out_train:
         with io.open(output_test, "w", encoding="utf8") as fd_out_test:
-            process_posts(fd_in, fd_out_train, fd_out_test, "<python>")
+            process_posts(fd_in, fd_out_train, fd_out_test, "<r>")
+

--- a/example-get-started/code/src/requirements.txt
+++ b/example-get-started/code/src/requirements.txt
@@ -1,4 +1,6 @@
+dvclive
 pandas
 pyaml
 scikit-learn
 scipy
+matplotlib

--- a/example-get-started/code/src/train.py
+++ b/example-get-started/code/src/train.py
@@ -20,7 +20,7 @@ n_est = params["n_est"]
 min_split = params["min_split"]
 
 with open(os.path.join(input, "train.pkl"), "rb") as fd:
-    matrix = pickle.load(fd)
+    matrix, _ = pickle.load(fd)
 
 labels = np.squeeze(matrix[:, 1].toarray())
 x = matrix[:, 2:]

--- a/example-get-started/deploy.sh
+++ b/example-get-started/deploy.sh
@@ -17,7 +17,9 @@ popd
 
 # Requires AWS CLI and write access to `s3://dvc-public/code/get-started/`.
 mv $PACKAGE_DIR/$PACKAGE .
-aws s3 cp --acl public-read $PACKAGE s3://dvc-public/code/get-started/$PACKAGE
+#aws s3 cp --acl public-read $PACKAGE s3://dvc-public/code/get-started/$PACKAGE
+
+exit
 
 # Sanity check
 wget https://code.dvc.org/get-started/$PACKAGE -O $TEST_PACKAGE

--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -60,7 +60,7 @@ git tag -a "1-dvc-init" -m "DVC initialized."
 
 mkdir data
 dvc get https://github.com/iterative/dataset-registry \
-  get-started/data.xml -o data/data.xml
+  get-started/data.xml -o data/data.xml --rev 95d720c467496ea6c15dd2c5d5ad48bbb631d8b1
 dvc add data/data.xml --desc "Initial XML StackOverflow dataset (raw data)"
 git add data/.gitignore data/data.xml.dvc
 tick
@@ -79,7 +79,7 @@ dvc push
 
 rm data/data.xml data/data.xml.dvc
 dvc import https://github.com/iterative/dataset-registry \
-  get-started/data.xml -o data/data.xml \
+  get-started/data.xml -o data/data.xml --rev 95d720c467496ea6c15dd2c5d5ad48bbb631d8b1 \
   --desc "Imported raw data (tracks source updates)"
 git add data/data.xml.dvc
 tick
@@ -87,7 +87,8 @@ git commit -m "Import raw data (overwrite)"
 git tag -a "4-import-data" -m "Data file overwritten with an import."
 dvc push
 
-wget https://code.dvc.org/get-started/code.zip
+cp $HERE/code.zip .
+#wget https://code.dvc.org/get-started/code.zip
 unzip code.zip
 rm -f code.zip
 pip install -r src/requirements.txt
@@ -127,27 +128,35 @@ git commit -m "Create ML pipeline stages"
 git tag -a "7-ml-pipeline" -m "ML pipeline created."
 dvc push
 
+
 dvc run -n evaluate \
   -d src/evaluate.py -d model.pkl -d data/features \
-  -M scores.json \
-  --plots-no-cache prc.json \
-  --plots-no-cache roc.json \
-  python src/evaluate.py model.pkl data/features scores.json prc.json roc.json
-dvc plots modify prc.json -x recall -y precision
-dvc plots modify roc.json -x fpr -y tpr
-git add .gitignore dvc.yaml dvc.lock prc.json roc.json scores.json
+  -M evaluation.json \
+  --plots-no-cache evaluation/plots/precision_recall.json \
+  --plots-no-cache evaluation/plots/roc.json \
+  --plots-no-cache evaluation/plots/predictions.json \
+  --plots evaluation/importance.png \
+  python src/evaluate.py model.pkl data/features
+dvc plots modify evaluation/plots/precision_recall.json -x recall -y precision
+dvc plots modify evaluation/plots/roc.json -x fpr -y tpr
+dvc plots modify evaluation/plots/predictions.json \
+    -x actual -y predicted -t confusion
+git add .gitignore dvc.yaml dvc.lock evaluation.json evaluation
 tick
 git commit -m "Create evaluation stage"
 git tag -a "baseline-experiment" -m "Baseline experiment evaluation"
 git tag -a "8-evaluation" -m "Baseline evaluation stage created."
 dvc push
 
-sed -e "s/max_features: 500/max_features: 1500/" -i".bkp" params.yaml
+
+sed -e "s/max_features: 100/max_features: 200/" -i".bkp" params.yaml
 sed -e "s/ngrams: 1/ngrams: 2/" -i".bkp" params.yaml
 dvc repro train
 tick
 git commit -am "Reproduce model using bigrams"
 git tag -a "9-bigrams-model" -m "Model retrained using bigrams."
+dvc push
+
 
 dvc repro evaluate
 tick
@@ -156,12 +165,14 @@ git tag -a "bigrams-experiment" -m "Bigrams experiment evaluation"
 git tag -a "10-bigrams-experiment" -m "Evaluated bigrams model."
 dvc push
 
-export GIT_AUTHOR_NAME=" Dave Berenbaum"
+
+export GIT_AUTHOR_NAME="Dave Berenbaum"
 export GIT_AUTHOR_EMAIL="dave.berenbaum@gmail.com"
 export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
 export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 
-dvc exp run --set-param featurize.max_features=3000
+git checkout -b "tune-hyperparams"
+
 dvc exp run --queue --set-param train.min_split=8
 dvc exp run --queue --set-param train.min_split=64
 dvc exp run --queue --set-param train.min_split=2 --set-param train.n_est=100
@@ -176,6 +187,8 @@ git tag -a "random-forest-experiments" -m "Run experiments to tune random forest
 git tag -a "11-random-forest-experiments" -m "Tuned random forest classifier."
 dvc push
 
+git checkout main
+
 export GIT_AUTHOR_NAME="Dmitry Petrov"
 export GIT_AUTHOR_EMAIL="dmitry.petrov@nevesomo.com"
 export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
@@ -183,10 +196,11 @@ export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 
 git checkout -b "try-large-dataset"
 
-dvc update data/data.xml.dvc --rev 100K
+dvc update data/data.xml.dvc --rev cf6481baf56f156aa0876709cc231aaf3f3a3c29
+sed -e "s/max_features: 200/max_features: 500/" -i".bkp" params.yaml
 dvc repro
 dvc push
-git commit -am "Try 100K dataset (4x data)"
+git commit -am "Try a 40K dataset (4x data)"
 
 popd
 
@@ -215,6 +229,7 @@ cd build/example-get-started
 git remote add origin git@github.com:iterative/example-get-started.git
 git push --force origin main
 git push --force origin try-large-dataset
+git push --force origin tune-hyperparams
 git push --force origin --tags
 
 Run these to drop and then rewrite the experiment references on the repo:


### PR DESCRIPTION
EDITs by @shcheklein:

Corresponding repo to play with: https://studio.iterative.ai/user/shcheklein/views/example-get-started-r7898c5e32

(a few lines in the PR will be uncommented / reverted before actual merge, after testing)

It changes example get started:

- To use a clean dataset (thus 2.5x smaller)
- Less number of features (3000 -> 100/200). Since dataset is better it's now enough - should be way better memory footprint
- More plots - confusion matrix + forest analysis (most useful feature)
- CML report includes confusion matrix
- Two branches - more data, hyperparams tuning

-------

TODO:

- [x] Waiting for https://github.com/iterative/dvclive/pull/189
