### PR TITLE
get-started: compare with main or previous commit in the CML workflow

### DIFF
--- a/example-get-started/code/.github/workflows/cml.yaml
+++ b/example-get-started/code/.github/workflows/cml.yaml
@@ -14,13 +14,14 @@ jobs:
           echo "# CML Report" > report.md
 
           echo "## Plots" >> report.md
-          dvc plots diff bigrams-experiment workspace \
+          dvc plots diff main \
             --show-vega --targets prc.json > vega.json
           vl2svg vega.json prc.svg
           cml publish prc.svg --title "Precision & Recall" --md >> report.md
 
           echo "## Metrics" >> report.md
           echo "### bigrams-experiment → workspace" >> report.md
-          dvc metrics diff bigrams-experiment --show-md >> report.md
+          PREVIOUS_REV=$(if [ ${GITHUB_REF##*/}x = "main"x ]; then echo "HEAD^1"; else echo "main"; fi)
+          dvc metrics diff $PREVIOUS_REV --show-md >> report.md
 
           cml send-comment report.md

--- a/example-get-started/code/.github/workflows/cml.yaml
+++ b/example-get-started/code/.github/workflows/cml.yaml
@@ -21,7 +21,7 @@ jobs:
 
           echo "## Metrics" >> report.md
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]] ; then
-            PREVIOUS_REF='HEAD^1'
+            PREVIOUS_REF='HEAD~1'
           else
             PREVIOUS_REF='main'
           fi

--- a/example-get-started/code/.github/workflows/cml.yaml
+++ b/example-get-started/code/.github/workflows/cml.yaml
@@ -20,8 +20,12 @@ jobs:
           cml publish prc.svg --title "Precision & Recall" --md >> report.md
 
           echo "## Metrics" >> report.md
-          echo "### bigrams-experiment → workspace" >> report.md
-          PREVIOUS_REV=$(if [ ${GITHUB_REF##*/}x = "main"x ]; then echo "HEAD^1"; else echo "main"; fi)
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]] ; then
+            PREVIOUS_REF='HEAD^1'
+          else
+            PREVIOUS_REF='main'
+          fi
+          echo "### $PREVIOUS_REV → workspace" >> report.md
           dvc metrics diff $PREVIOUS_REV --show-md >> report.md
 
           cml send-comment report.md


### PR DESCRIPTION
In PRs we now compare metrics and plots with `main`, in the `main` itself we are comparing with `HEAD^1`

Closes https://github.com/iterative/example-repos-dev/issues/58 

Needs some testing, but for simplicity I'm postponing this until I can run everything end to end with all the changes I want to make: add a separate branch for the 4x data, add codespaces, change author names (I believe any human name and face is better than Olivaw)