### PR TITLE
simplify dvc exp push commands

### DIFF
--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -219,8 +219,8 @@ git push --force origin --tags
 
 Run these to drop and then rewrite the experiment references on the repo:
 
-git ls-remote origin "refs/exps/*" | awk '{print \\$2}' | xargs -n 1 git push -d origin
-dvc exp list --all --names-only | xargs -n 1 dvc exp push origin
+dvc exp remove -A -g origin
+dvc exp push origin -A
 
 To create a PR from the `try-large-dataset` branch:
 


### PR DESCRIPTION
`dvc exp` commands now support removing and pushing multiple experiments, so we don't need the previous `xargs` hacks.