### PR TITLE
get-started: use fractional min_split

### DIFF
--- a/example-get-started/code/params.yaml
+++ b/example-get-started/code/params.yaml
@@ -9,5 +9,5 @@ featurize:
 train:
   seed: 20170428
   n_est: 50
-  min_split: 2
+  min_split: 0.01
 


### PR DESCRIPTION
Using a fractional value for `min_split` (see https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.RandomForestClassifier.html) reduces overfitting and scales better to different sample sizes.

train.min_split=2

![visualization(6)](https://user-images.githubusercontent.com/2308172/169882667-06c137c5-7ad0-49fa-95d7-fd1b03805314.png)

train.min_split=0.01

![visualization(7)](https://user-images.githubusercontent.com/2308172/169882695-734a8c36-2330-4ab6-bfff-cbe24117788d.png)


