### PR TITLE
MLEM: release 0.3.0

### DIFF
--- a/example-mlem-get-started/code/README.md
+++ b/example-mlem-get-started/code/README.md
@@ -7,7 +7,7 @@ introduction into basic MLEM concepts.
 - The `main` branch contains the results of following the Get Started. Results
   of each step can be found in Git tags.
 - The `dvc` branch contains the results of the
-  [MLEM+DVC tutorial](http://mlem.ai/doc/use-cases/dvc).
+  [MLEM+DVC tutorial](https://mlem.ai/doc/user-guide/dvc).
 
 🐛 Please report any issues found in this project here -
 [example-repos-dev](https://github.com/iterative/example-repos-dev).

--- a/example-mlem-get-started/code/src/evaluate.py
+++ b/example-mlem-get-started/code/src/evaluate.py
@@ -7,13 +7,13 @@ from sklearn.datasets import load_iris
 
 def main():
     data, y_true = load_iris(return_X_y=True, as_frame=True)
-    y_pred = apply("rf", data, method="predict_proba")
+    y_pred = apply("models/rf", data, method="predict_proba")
     roc_auc = metrics.roc_auc_score(y_true, y_pred, multi_class="ovr")
 
     with open("metrics.json", "w") as fd:
         json.dump({"roc_auc": roc_auc}, fd, indent=4)
 
-    save(data, "iris.csv")
+    save(data, "data/iris.csv")
 
 
 if __name__ == "__main__":

--- a/example-mlem-get-started/code/src/train.py
+++ b/example-mlem-get-started/code/src/train.py
@@ -13,7 +13,7 @@ def main():
 
     save(
         rf,
-        "rf",
+        "models/rf",
         sample_data=data,
     )
 

--- a/example-mlem-get-started/generate.sh
+++ b/example-mlem-get-started/generate.sh
@@ -35,7 +35,9 @@ if [ ! -d "$BUILD_PATH/.venv" ]; then
   echo '.venv/' > .gitignore
   pip install -r $HERE/code/src/requirements.txt
   git clone https://github.com/iterative/mlem.git
-  pip install -e ./mlem
+  cd mlem
+  git checkout release/0.3.0
+  pip install -e .
 fi
 popd
 
@@ -105,7 +107,7 @@ mlem init s3://example-mlem-get-started
 mlem clone rf s3://example-mlem-get-started/rf
 
 
-mlem declare builder pip pip_config -c target=build/ -c package_name=example_mlem_get_started
+mlem declare builder pip pip_config --target=build/ --package_name=example_mlem_get_started
 git add .mlem
 tick
 git commit -m "Add package config"
@@ -113,7 +115,7 @@ git tag -a "4-pack" -m "Pip package config added"
 
 
 mlem declare env heroku staging
-mlem declare deployment heroku myservice -c app_name=example-mlem-get-started-app -c model=rf -c env=staging
+mlem declare deployment heroku myservice --app_name=example-mlem-get-started-app --model.path=rf --env=staging
 git add .mlem
 tick
 git commit -m "Add env and deploy meta"

--- a/example-mlem-get-started/generate.sh
+++ b/example-mlem-get-started/generate.sh
@@ -36,7 +36,6 @@ if [ ! -d "$BUILD_PATH/.venv" ]; then
   pip install -r $HERE/code/src/requirements.txt
   git clone https://github.com/iterative/mlem.git
   cd mlem
-  git checkout release/0.3.0
   pip install -e .
 fi
 popd

--- a/example-mlem-get-started/generate.sh
+++ b/example-mlem-get-started/generate.sh
@@ -84,39 +84,39 @@ git tag -a "0-git-init" -m "Git initialized."
 
 mlem init
 tick
-git add .mlem
+git add .mlem.yaml
 git commit -m "Initialize MLEM project"
 git tag -a "1-mlem-init" -m "MLEM initialized."
 
 
 python train.py
-git add .mlem
+git add models
 tick
 git commit -m "Train the model"
 git tag -a "2-train" -m "Model trained."
 
 
 python evaluate.py
-git add metrics.json
+git add data metrics.json
 tick
 git commit -m "Evaluate model"
 git tag -a "3-eval" -m "Metrics calculated"
 
 
 mlem init s3://example-mlem-get-started
-mlem clone rf s3://example-mlem-get-started/rf
+mlem clone models/rf s3://example-mlem-get-started/rf
 
 
-mlem declare builder pip pip_config --target=build/ --package_name=example_mlem_get_started
-git add .mlem
+mlem declare builder pip pip_config.mlem --target=build/ --package_name=example_mlem_get_started
+git add pip_config.mlem
 tick
 git commit -m "Add package config"
 git tag -a "4-pack" -m "Pip package config added"
 
 
 mlem declare env heroku staging
-mlem declare deployment heroku myservice --app_name=example-mlem-get-started-app --model.path=rf --env=staging
-git add .mlem
+mlem declare deployment heroku app.mlem --app_name=example-mlem-get-started-app --model.path=rf --env=staging
+git add app.mlem
 tick
 git commit -m "Add env and deploy meta"
 git tag -a "5-deploy-meta" -m "Target env and deploy meta added"
@@ -124,10 +124,11 @@ git tag -a "5-deploy-meta" -m "Target env and deploy meta added"
 
 if heroku apps:info example-mlem-get-started-app; then
   heroku apps:destroy example-mlem-get-started-app --confirm example-mlem-get-started-app
+  heroku container:login
 fi
 
-mlem deployment run myservice
-git add .mlem
+mlem deployment run --load app.mlem --model models/rf
+git add app.mlem.state
 tick
 git commit -m "Deploy service"
 git tag -a "6-deploy-create" -m "Deployment created"
@@ -150,7 +151,7 @@ git tag -a "7-dvc-dvc-init" -m "DVC Initialized"
 mlem config set core.storage.type dvc
 echo "/**/?*.mlem" > .dvcignore
 git add .dvcignore
-git rm -r --cached .mlem
+git rm -r --cached models data
 tick
 git commit -m "Configure MLEM for DVC"
 git tag -a "8-dvc-mlem-config" -m "Configured MLEM to work with DVC"
@@ -158,8 +159,8 @@ git tag -a "8-dvc-mlem-config" -m "Configured MLEM to work with DVC"
 
 python train.py
 python evaluate.py
-dvc add .mlem/model/rf .mlem/data/*.csv
-git add .mlem .dvc metrics.json
+dvc add models/rf data/*.csv
+git add models data .dvc metrics.json
 tick
 git commit -m "Run code with DVC"
 git tag -a "9-dvc-save-models" -m "Saved models with DVC storage"

--- a/example-mlem-get-started/generate.sh
+++ b/example-mlem-get-started/generate.sh
@@ -112,23 +112,13 @@ tick
 git commit -m "Add package config"
 git tag -a "4-pack" -m "Pip package config added"
 
-
-mlem declare env heroku staging
-mlem declare deployment heroku app.mlem --app_name=example-mlem-get-started-app --model.path=rf --env=staging
-git add app.mlem
-tick
-git commit -m "Add env and deploy meta"
-git tag -a "5-deploy-meta" -m "Target env and deploy meta added"
-
-
 if heroku apps:info example-mlem-get-started-app; then
   heroku apps:destroy example-mlem-get-started-app --confirm example-mlem-get-started-app
   heroku container:login
 fi
 
-mlem deployment run --load app.mlem --model models/rf
-git add app.mlem.state
-tick
+mlem deployment run heroku app.mlem --app_name=example-mlem-get-started-app --model=models/rf
+git add app.mlem app.mlem.state
 git commit -m "Deploy service"
 git tag -a "6-deploy-create" -m "Deployment created"
 
@@ -149,7 +139,7 @@ git tag -a "7-dvc-dvc-init" -m "DVC Initialized"
 
 mlem config set core.storage.type dvc
 echo "/**/?*.mlem" > .dvcignore
-git add .dvcignore
+git add .dvcignore .mlem.yaml
 git rm -r --cached models data
 tick
 git commit -m "Configure MLEM for DVC"


### PR DESCRIPTION
Updating `example-mlem-get-started` to run with MLEM 0.3.0

TODO:
- [x] remove `git checkout release/0.3.0` from `generate.sh`

Can be finished after fixing this bug: https://github.com/iterative/mlem/issues/418