### PR TITLE
example-dvc-experiments: remove upper bound on tensorflow

### DIFF
--- a/example-dvc-experiments/code/requirements-macos.txt
+++ b/example-dvc-experiments/code/requirements-macos.txt
@@ -1,5 +1,5 @@
 dvc[s3]>2.33.2
-tensorflow-macos>=2.6,<2.7
+tensorflow-macos>=2.6
 ruamel.yaml>=0.17,<0.18
 imageio>=2.9,<3
 dvclive>=1.0

--- a/example-dvc-experiments/code/requirements.txt
+++ b/example-dvc-experiments/code/requirements.txt
@@ -1,5 +1,4 @@
-dvc[s3]>2.33.2
-tensorflow>=2.5,<2.6
+tensorflow>=2.5
 ruamel.yaml>=0.17,<0.18
 imageio>=2.9,<3
 dvclive>=1.0


### PR DESCRIPTION
Seems like the requirements are a bit overly restrictive here and the pinned versions are no longer available. I think it's enough to have a lower bound (if there's a tensorflow 3.0, we can revisit).