### PR TITLE
GTO: fix CI

### DIFF
--- a/example-gto/code/mlem/.github/workflows/deploy-model-with-mlem.yml
+++ b/example-gto/code/mlem/.github/workflows/deploy-model-with-mlem.yml
@@ -30,8 +30,8 @@ jobs:
       path: ${{ steps.gto.outputs.path }}
   deploy-model:
     name: Deploy a MLEM model (act on assigning a new stage)
-    needs: check
-    if: needs.check.outputs.event == 'assignment'
+    needs: parse-git-tag
+    if: needs.parse-git-tag.outputs.event == 'assignment'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -46,4 +46,4 @@ jobs:
         pip install -r requirements.txt
     - name: Run `mlem deploy``
       run: |
-        mlem deployment run --load deploy/${{ needs.check.outputs.stage }} --model ${{ needs.check.outputs.path }}
+        mlem deployment run --load deploy/${{ needs.parse-git-tag.outputs.stage }} --model ${{ needs.parse-git-tag.outputs.path }}

--- a/example-gto/code/mlem/.mlem.yaml
+++ b/example-gto/code/mlem/.mlem.yaml
@@ -1,3 +1,3 @@
 core:
  state:
-   uri: s3://gto-mlem-example/deployment-state
+   uri: s3://gto-mlem-example/mlem-deployment-state

--- a/example-gto/code/mlem/deploy/dev.mlem
+++ b/example-gto/code/mlem/deploy/dev.mlem
@@ -1,3 +1,3 @@
 object_type: deployment
 type: heroku
-app_name: gto-example-mlem-app-dev
+app_name: mlem-dev

--- a/example-gto/code/mlem/deploy/prod.mlem
+++ b/example-gto/code/mlem/deploy/prod.mlem
@@ -1,3 +1,3 @@
 object_type: deployment
 type: heroku
-app_name: gto-example-mlem-app-prod
+app_name: mlem-prod

--- a/example-gto/code/mlem/deploy/staging.mlem
+++ b/example-gto/code/mlem/deploy/staging.mlem
@@ -1,3 +1,3 @@
 object_type: deployment
 type: heroku
-app_name: gto-example-mlem-app-staging
+app_name: mlem-staging


### PR DESCRIPTION
Follow-up for #133 
Fixing CI and renaming apps due to `gto-example-mlem-app-prod` already taken.

I re-generated the example-gto repo again, everything looks fine https://github.com/iterative/example-gto/actions
Now for heroku apps we use names `mlem-dev`, `mlem-staging` and `mlem-prod`. All belong to Olivaw's account.

Feel free to merge if looks correct.