### PR TITLE
Add devcontainer to run in Codespaces

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "example-repos-dev",
+  "image": "mcr.microsoft.com/devcontainers/python:3.10",
+  "extensions": ["Iterative.dvc", "ms-python.python", "redhat.vscode-yaml"],
+  "features": {
+      "ghcr.io/devcontainers/features/nvidia-cuda:1": {
+          "installCudnn": true
+      },
+      "ghcr.io/saml-to/devcontainer-features/assume-aws-role:1": {
+          "role": "arn:aws:iam::342840881361:role/iterative-saml-codespaces"
+      },
+    "ghcr.io/devcontainers/features/aws-cli:1": {}
+  }
+}


### PR DESCRIPTION
Add `.devcontainer.json` config for Codespaces per https://github.com/iterative/example-repos-dev/pull/161#discussion_r1088142263

Related: https://github.com/iterative/saml-to repo to define [SAML.to](https://saml.to/) config to assume role automatically that has access to S3 (including `dvc-private` and `dvc-public`) buckets.

To debug (if something goes wrong) the SAML.to logic one can run:

```cli
$ assume-aws-role
```

Also make sure (ask GH admins) that SAML.to app has access to the https://github.com/iterative/saml-to repo.