### PR TITLE
example-get-started: add link to Studio wiki in instructions

### DIFF
--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -280,6 +280,10 @@ gh pr create -t "Run experiments tuning random forest params" \
    -b "Better RF split and number of estimators based on small grid search." \
    -B main -H tune-hyperparams
 
+To update the project in Studio, follow the instructions at:
+
+https://github.com/iterative/studio/wiki/Updating-and-synchronizing-demo-project
+
 Finally, return to the directory where you started:
 
 cd ../..

--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -149,6 +149,7 @@ dvc stage add -n evaluate \
   python src/evaluate.py model.pkl data/features
 echo "plots:
   - ROC:
+      template: simple
       x: fpr
       y:
         eval/live/plots/sklearn/roc/train.json: tpr
@@ -160,6 +161,7 @@ echo "plots:
         eval/live/plots/sklearn/cm/train.json: predicted
         eval/live/plots/sklearn/cm/test.json: predicted
   - Precision-Recall:
+      template: simple
       x: recall
       y:
         eval/prc/train.json: precision


### PR DESCRIPTION
Per https://github.com/iterative/example-repos-dev/pull/181#issuecomment-1416894583