### PR TITLE
`example-gto`: remove `annotate` and move artifacts to `dvc.yaml`

### DIFF
--- a/example-gto/code/.github/workflows/gto-act-on-tags.yml
+++ b/example-gto/code/.github/workflows/gto-act-on-tags.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: "GTO: figure out what was registered/promoted and show the Registry state"
       id: gto
-      uses: iterative/gto-action@v1
+      uses: iterative/gto-action@v2
     - uses: actions/setup-python@v2
     - name: Install dependencies
       run: |

--- a/example-gto/code/mlem/.github/workflows/deploy-model-with-mlem.yml
+++ b/example-gto/code/mlem/.github/workflows/deploy-model-with-mlem.yml
@@ -16,13 +16,15 @@ jobs:
     - uses: actions/checkout@v3
     - name: "GTO: figure out what was registered/promoted and show the Registry state"
       id: gto
-      uses: iterative/gto-action@v1
+      uses: iterative/gto-action@v2
+      with:
+        download: true
     # we define the Job outputs here to let the next Job use them
     outputs:
       name: ${{ steps.gto.outputs.name }}
       stage: ${{ steps.gto.outputs.stage }}
       event: ${{ steps.gto.outputs.event }}
-      path: ${{ steps.gto.outputs.path }}
+      path: ${{ steps.gto.outputs.path }}  # the path the model was `dvc get` to
   deploy-model:
     name: Deploy a MLEM model (act on assigning a new stage)
     needs: parse-git-tag

--- a/example-gto/code/mlem/.github/workflows/deploy-model-with-mlem.yml
+++ b/example-gto/code/mlem/.github/workflows/deploy-model-with-mlem.yml
@@ -24,7 +24,7 @@ jobs:
       name: ${{ steps.gto.outputs.name }}
       stage: ${{ steps.gto.outputs.stage }}
       event: ${{ steps.gto.outputs.event }}
-      path: ${{ steps.gto.outputs.path }}  # the path the model was `dvc get` to
+      path: ${{ steps.gto.outputs.path }}
   deploy-model:
     name: Deploy a MLEM model (act on assigning a new stage)
     needs: parse-git-tag

--- a/example-gto/code/mlem/.github/workflows/deploy-model-with-mlem.yml
+++ b/example-gto/code/mlem/.github/workflows/deploy-model-with-mlem.yml
@@ -17,8 +17,6 @@ jobs:
     - name: "GTO: figure out what was registered/promoted and show the Registry state"
       id: gto
       uses: iterative/gto-action@v2
-      with:
-        download: true
     # we define the Job outputs here to let the next Job use them
     outputs:
       name: ${{ steps.gto.outputs.name }}

--- a/example-gto/generate.sh
+++ b/example-gto/generate.sh
@@ -91,9 +91,19 @@ git add models requirements.txt
 tick
 git commit -am "Create models"
 
-gto annotate churn --type model --path models/churn.pkl --must-exist
-gto annotate segment --type model --path s3://mycorp/proj-ml/segm-model-2022-04-15.pt
-gto annotate cv-class --type model --path s3://mycorp/proj-ml/classif-v2.pt
+cat >> dvc.yaml<< EOF
+artifacts:
+  churn:
+    type: model
+    path: models/churn.pkl
+  segment:
+    type: model
+    path: s3://mycorp/proj-ml/segm-model-2022-04-15.pt
+  cv-class:
+    type: model
+    path: s3://mycorp/proj-ml/classif-v2.pt
+EOF
+
 git add artifacts.yaml
 tick
 git commit -m "Annotate models with GTO"

--- a/example-gto/generate.sh
+++ b/example-gto/generate.sh
@@ -44,7 +44,7 @@ source $BUILD_PATH/.venv/bin/activate
 
 TOTAL_TAGS=15
 STEP_TIME=100000
-SLEEP_TIME=30
+SLEEP_TIME=90
 BEGIN_TIME=$(($(date +%s) - (${TOTAL_TAGS} * ${STEP_TIME})))
 export TAG_TIME=${BEGIN_TIME}
 export GIT_AUTHOR_DATE="${TAG_TIME} +0000"
@@ -84,6 +84,9 @@ if $PUSH; then
   git ls-remote --tags origin | awk '/^(.*)(\s+)(.*[a-zA-Z0-9])$/ {print ":" $2}' | xargs git push origin
 fi
 
+echo "Initialize DVC"
+dvc init
+git commit -m "Initialize DVC"
 echo "Create new models"
 mkdir models
 echo "1st version" > models/churn.pkl
@@ -103,8 +106,8 @@ artifacts:
     type: model
     path: s3://mycorp/proj-ml/classif-v2.pt
 EOF
+git add dvc.yaml
 
-git add artifacts.yaml
 tick
 git commit -m "Annotate models with GTO"
 if $PUSH; then


### PR DESCRIPTION
- the repo can be re-generated already, although CI will fail
- we need to update GTO action to v2 to make it work in CI
- test repo for Studio BE should have a monorepo. Given `example-gto`, one can ~generate monorepo with simply
```sh
$ cp -r * example-gto example-gto/subrepo
$ cd example-gto
```
Now you'll have a very simple monorepo 🙌🏻 

cc @jellebouwman and @amritghimire re https://github.com/iterative/studio/issues/5504 - I'm not sure `demo-bank-customer-churn` is a monorepo, so if you need one, we can do this ^