### PR TITLE
example-get-started-experiments: use cpu-friendly arch

### DIFF
--- a/example-get-started-experiments/code/notebooks/TrainSegModel.ipynb
+++ b/example-get-started-experiments/code/notebooks/TrainSegModel.ipynb
@@ -45,7 +45,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -77,7 +76,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -120,7 +118,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -137,7 +134,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -185,33 +181,41 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
-    "train_arch = 'resnet18'\n",
+    "train_arch = 'shufflenet_v2_x2_0'\n",
     "models_dir = ROOT / \"models\"\n",
     "models_dir.mkdir(exist_ok=True)\n",
     "\n",
     "for base_lr in [0.001, 0.005, 0.01]:\n",
+    "    # initialize dvclive and optionally provide output path\n",
     "    with Live(str(ROOT / \"results\" / \"train\"), save_dvc_exp=True) as live:\n",
+    "        # log a parameter\n",
     "        live.log_param(\"train_arch\", train_arch)\n",
     "        fine_tune_args = {\n",
     "            'epochs': 8,\n",
     "            'base_lr': base_lr\n",
     "        }\n",
+    "        # log a dict of parameters\n",
     "        live.log_params(fine_tune_args)\n",
     "\n",
     "        learn = unet_learner(data_loader, \n",
     "                            arch=getattr(models, train_arch), \n",
     "                            metrics=DiceMulti)\n",
+    "        # train model and automatically capture metrics with DVCLiveCallback\n",
     "        learn.fine_tune(\n",
     "            **fine_tune_args,\n",
     "            cbs=[DVCLiveCallback(live=live)])\n",
     "\n",
     "        learn.export(fname=(models_dir / \"model.pkl\").absolute())\n",
     "\n",
+    "        # add additional post-training summary metrics\n",
     "        live.summary[\"evaluate/dice_multi\"] = evaluate(learn)\n",
     "\n",
+    "        # save model artifact to dvc\n",
     "        live.log_artifact(str(models_dir / \"model.pkl\"))"
    ]
   },
@@ -226,7 +230,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -243,7 +246,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -269,11 +271,18 @@
    "source": [
     "interp.plot_top_losses(k=5, alpha=0.7)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -287,9 +296,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9 (main, Jan 23 2023, 22:32:48) [GCC 10.2.1 20210110]"
+   "version": "3.10.6"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "949777d72b0d2535278d3dc13498b2535136f6dfe0678499012e853ee9abcab1"
@@ -297,5 +305,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/example-get-started-experiments/code/params.yaml
+++ b/example-get-started-experiments/code/params.yaml
@@ -6,7 +6,7 @@ data_split:
 
 train:
   valid_pct: 0.1
-  arch: resnet18
+  arch: shufflenet_v2_x2_0
   img_size: 256
   batch_size: 8
   fine_tune_args:


### PR DESCRIPTION
Changed model arch to something that runs in reasonable time on cpu since I think it's not feasible for everyone trying it out to have access to gpu (or they may have some restricted access to one that they don't want to use to demo a new tool). Performance is not quite as strong but it's not a dramatic dropoff:

<img width="960" alt="Screenshot 2023-04-14 at 9 52 12 AM" src="https://user-images.githubusercontent.com/2308172/232062992-044741f5-f899-4eee-a7c1-27ff34c03118.png">
