### PR TITLE
exp: drop aug_transforms for mac m1 compatibility

### DIFF
--- a/example-get-started-experiments/code/notebooks/TrainSegModel.ipynb
+++ b/example-get-started-experiments/code/notebooks/TrainSegModel.ipynb
@@ -38,7 +38,7 @@
     "from dvclive.fastai import DVCLiveCallback\n",
     "from fastai.data.all import Normalize, get_files\n",
     "from fastai.metrics import DiceMulti\n",
-    "from fastai.vision.all import (Resize, SegmentationDataLoaders, aug_transforms,\n",
+    "from fastai.vision.all import (Resize, SegmentationDataLoaders,\n",
     "                               imagenet_stats, models, unet_learner)\n",
     "from ruamel.yaml import YAML\n",
     "from PIL import Image"
@@ -111,7 +111,6 @@
     "        valid_pct=valid_pct,\n",
     "        item_tfms=Resize(img_size),\n",
     "        batch_tfms=[\n",
-    "            *aug_transforms(size=img_size),\n",
     "            Normalize.from_stats(*imagenet_stats),\n",
     "        ],\n",
     "    )"

--- a/example-get-started-experiments/code/params.yaml
+++ b/example-get-started-experiments/code/params.yaml
@@ -7,7 +7,6 @@ data_split:
 train:
   valid_pct: 0.1
   arch: shufflenet_v2_x2_0
-  img_size: 256
   batch_size: 8
   fine_tune_args:
     epochs: 8

--- a/example-get-started-experiments/code/src/train.py
+++ b/example-get-started-experiments/code/src/train.py
@@ -11,7 +11,6 @@ from fastai.metrics import DiceMulti
 from fastai.vision.all import (
     Resize,
     SegmentationDataLoaders,
-    aug_transforms,
     imagenet_stats,
     models,
     unet_learner,
@@ -42,7 +41,6 @@ def train():
         valid_pct=params.train.valid_pct,
         item_tfms=Resize(params.train.img_size),
         batch_tfms=[
-            *aug_transforms(size=params.train.img_size),
             Normalize.from_stats(*imagenet_stats),
         ],
     )


### PR DESCRIPTION
Drops the `aug_transforms` calls, which AFAIU were only being used to set the output size of the images. This was making the repo incompatible with mac m1, which works out of the box. Model still seems to perform fine without them.