### PR TITLE
More CI workflow updates

### DIFF
--- a/example-get-started-experiments/code/.github/workflows/run-experiment.yml
+++ b/example-get-started-experiments/code/.github/workflows/run-experiment.yml
@@ -59,15 +59,14 @@ jobs:
 
       - run: pip install -r requirements.txt
 
-      - name: Trrain
+      - name: Train
         env:
           REPO_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           STUDIO_TOKEN: ${{ secrets.STUDIO_TOKEN }}
           DVCLIVE_LOGLEVEL: DEBUG
         run: |
           cml ci --fetch-depth 0
-          dvc pull
-          dvc exp run ${{ github.event.inputs.exp-run-args }}
+          dvc exp run --pull --allow-missing ${{ github.event.inputs.exp-run-args }}
           dvc remote add --local push_remote s3://dvc-public/remote/get-started-pools 
 
       - name: Workflow Dispatch Sharing
@@ -75,7 +74,7 @@ jobs:
         env:
           STUDIO_TOKEN: ${{ secrets.STUDIO_TOKEN }}
         run: |
-          dvc exp push origin --rev HEAD -r push_remote
+          dvc exp push origin -r push_remote
 
       - name: Commit-based Sharing
         if: github.actor == 'iterative-studio[bot]'

--- a/example-get-started-experiments/code/.github/workflows/run-experiment.yml
+++ b/example-get-started-experiments/code/.github/workflows/run-experiment.yml
@@ -1,15 +1,14 @@
 name: Run Experiment
 on: 
+
+  push:
+
   workflow_dispatch:
     inputs:
       exp-run-args:
         description: 'Args to be passed to dvc exp run call'
         required: false
         default: ''
-
-  pull_request:
-    branches:    
-      - main
 
 permissions:
   contents: write
@@ -22,6 +21,7 @@ jobs:
     if: ${{ (github.actor == 'iterative-studio[bot]') || (github.event_name == 'workflow_dispatch') }} 
     environment: cloud
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v3
       - uses: iterative/setup-cml@v1
@@ -48,6 +48,7 @@ jobs:
     container:
       image: iterativeai/cml:0-dvc2-base1-gpu
       options: --gpus all --ipc host
+
     steps:
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1

--- a/example-get-started-experiments/code/.github/workflows/run-experiment.yml
+++ b/example-get-started-experiments/code/.github/workflows/run-experiment.yml
@@ -58,7 +58,6 @@ jobs:
           role-duration-seconds: 43200
 
       - run: pip install -r requirements.txt
-      - run: cml ci --fetch-depth 0
 
       - name: Trrain
         env:
@@ -66,6 +65,7 @@ jobs:
           STUDIO_TOKEN: ${{ secrets.STUDIO_TOKEN }}
           DVCLIVE_LOGLEVEL: DEBUG
         run: |
+          cml ci --fetch-depth 0
           dvc pull
           dvc exp run ${{ github.event.inputs.exp-run-args }}
           dvc remote add --local push_remote s3://dvc-public/remote/get-started-pools 

--- a/example-get-started-experiments/code/.github/workflows/run-experiment.yml
+++ b/example-get-started-experiments/code/.github/workflows/run-experiment.yml
@@ -69,28 +69,21 @@ jobs:
           cml ci --fetch-depth 0
           dvc exp run ${{ github.event.inputs.exp-run-args }}
           dvc remote add --local push_remote s3://dvc-public/remote/get-started-pools 
-          dvc push -r push_remote
-  
-      - name: Report
-        env:
-          REPO_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        run: |
-          echo "## Metrics" > report.md
-          dvc metrics diff main --md >> report.md
-          echo "## Params" >> report.md
-          dvc params diff main --md >> report.md
 
-      - name: Workflow Dispatch PR
+      - name: Workflow Dispatch Sharing
         if: github.event_name == 'workflow_dispatch'
-        env:
-          REPO_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
-          cml pr --skip-ci .
+          dvc exp push origin --rev HEAD -r push_remote
 
-      - name: Studio PR
+      - name: Commit-based Sharing
         if: github.actor == 'iterative-studio[bot]'
         env:
           REPO_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
+          dvc push -r push_remote
           cml pr --squash --skip-ci .
+          echo "## Metrics" > report.md
+          dvc metrics diff main --md >> report.md
+          echo "## Params" >> report.md
+          dvc params diff main --md >> report.md
           cml comment create --pr report.md

--- a/example-get-started-experiments/code/.github/workflows/run-experiment.yml
+++ b/example-get-started-experiments/code/.github/workflows/run-experiment.yml
@@ -58,6 +58,7 @@ jobs:
           role-duration-seconds: 43200
 
       - run: pip install -r requirements.txt
+      - run: cml ci --fetch-depth 0
 
       - name: Trrain
         env:
@@ -66,12 +67,13 @@ jobs:
           DVCLIVE_LOGLEVEL: DEBUG
         run: |
           dvc pull
-          cml ci --fetch-depth 0
           dvc exp run ${{ github.event.inputs.exp-run-args }}
           dvc remote add --local push_remote s3://dvc-public/remote/get-started-pools 
 
       - name: Workflow Dispatch Sharing
         if: github.event_name == 'workflow_dispatch'
+        env:
+          STUDIO_TOKEN: ${{ secrets.STUDIO_TOKEN }}
         run: |
           dvc exp push origin --rev HEAD -r push_remote
 


### PR DESCRIPTION
- Use `on push` trigger

Using `pull_request` requires modifying the action/checkout step in order to properly set the git HEAD (which was causing the experiments to appear as detached in Studio)

on push has the same effect and we use the github actor to filter events

- Use `exp push` for sharing in workflow dispatch mode.

You can manually replicate from github UI the future Studio UI behavior