### PR TITLE
example-get-started-experiments: add gitlab workflow

### DIFF
--- a/example-get-started-experiments/README.md
+++ b/example-get-started-experiments/README.md
@@ -33,6 +33,17 @@ And this to clean the remote cache to only contain the last iteration:
 dvc gc -c --all-commits --all-experiments
 ```
 
+To push a copy to GitLab:
+
+```
+git remote add gitlab git@gitlab.com:iterative.ai/example-get-started-experiments.git
+git push --force gitlab main
+# we push git tags one by one for Studio to receive webhooks:
+git tag --sort=creatordate | xargs -n 1 git push --force gitlab
+# push experiments
+dvc exp remove -A -g gitlab
+dvc exp push gitlab -A
+```
 Finally, return to the directory where you started:
 
 ```

--- a/example-get-started-experiments/code/.gitlab-ci.yml
+++ b/example-get-started-experiments/code/.gitlab-ci.yml
@@ -1,0 +1,52 @@
+variables:
+  EXP_RUN_ARGS: ""
+deploy-runner:
+  image: iterativeai/cml:0-dvc2-base1
+  script:
+  - pip install awscli
+  - >
+    CREDENTIALS=($(aws sts assume-role-with-web-identity
+    --region=us-east-1
+    --role-arn=arn:aws:iam::342840881361:role/SandboxUser
+    --role-session-name=GitLab
+    --duration-seconds=3600
+    --web-identity-token="$CI_JOB_JWT_V2"
+    --query="Credentials.[AccessKeyId,SecretAccessKey,SessionToken]"
+    --output=text))
+  - export AWS_ACCESS_KEY_ID="${CREDENTIALS[0]}"
+  - export AWS_SECRET_ACCESS_KEY="${CREDENTIALS[1]}"
+  - export AWS_SESSION_TOKEN="${CREDENTIALS[2]}"
+  - aws sts get-caller-identity
+  - >
+    cml runner launch --single \
+      --labels=cml \
+      --cloud=aws \
+      --cloud-region=us-east \
+      --cloud-hdd-size=40 \
+      --cloud-type=g5.2xlarge
+runner-job:
+  needs:
+    - deploy-runner
+  tags:
+    - cml
+  image: iterativeai/cml:0-dvc2-base1
+  script:
+  - pip install awscli
+  - >
+    CREDENTIALS=($(aws sts assume-role-with-web-identity
+    --region=us-east-1
+    --role-arn=arn:aws:iam::342840881361:role/SandboxUser
+    --role-session-name=GitLab
+    --duration-seconds=3600
+    --web-identity-token="$CI_JOB_JWT_V2"
+    --query="Credentials.[AccessKeyId,SecretAccessKey,SessionToken]"
+    --output=text))
+  - export AWS_ACCESS_KEY_ID="${CREDENTIALS[0]}"
+  - export AWS_SECRET_ACCESS_KEY="${CREDENTIALS[1]}"
+  - export AWS_SESSION_TOKEN="${CREDENTIALS[2]}"
+  - aws sts get-caller-identity
+  - pip install -r requirements.txt
+  - cml ci
+  - dvc exp run --pull --allow-missing $EXP_RUN_ARGS
+  - dvc remote add --local push_remote s3://dvc-public/remote/get-started-pools 
+  - dvc exp push origin -r push_remote


### PR DESCRIPTION
There's a working example in https://gitlab.com/iterative.ai/example-get-started-experiments. This doesn't have any of the conditional logic of commit-based vs. manual/workflow dispatch, but otherwise it matches GH as much as I could. 

I'm not sure whether it's worth merging now or spending much more time on at the moment because the current level of complexity feels overwhelming and not something I think can be resolved by polishing, since a lot of the complexity is in setting up the CI workflow and cloud runner.

Some examples:
- It requires setting up a token in Gitlab and adding it to repo variables, which isn't visible in the script.
- It requires getting the Studio token and adding it as a repo variable, which also isn't visible in the script.
- Setting up credentials for the cloud can be done in so many ways. Here we use OIDC, which is good but means you need to create an OIDC identity provider and an IAM role that you assign to it, and then need to run the complicated steps you see in this workflow in two different places. And this only covers one way to do this in one cloud provider.
- If you don't use OIDC, you would to add credentials directly into the script. You can add these as masked environment variables, but it still seems pretty insecure, and more advanced [secrets management](https://docs.gitlab.com/ee/ci/secrets/) in Gitlab doesn't look simple.
- All this complexity means you will inevitably need to modify the script, but that requires knowledge about Gitlab CI, AWS, DVC, and CML to understand what's happening and what you should and shouldn't touch.