### PR TITLE
fix(example-get-started): avoid inf and nans in prc plot output

### DIFF
--- a/example-get-started/code/src/evaluate.py
+++ b/example-get-started/code/src/evaluate.py
@@ -56,7 +56,9 @@ def evaluate(model, matrix, split, live, save_path):
             {
                 "prc": [
                     {"precision": p, "recall": r, "threshold": t}
-                    for p, r, t in prc_points
+                    # https://github.com/scikit-learn/scikit-learn/pull/26194/files
+                    # Threshold can be inf now and Vega CLI tools don't like it.
+                    for p, r, t in prc_points if math.isfinite(t)
                 ]
             },
             fd,


### PR DESCRIPTION
Fixes #225 

Since we have PRs broken in the example repo https://github.com/iterative/example-get-started/actions/runs/5484365547/job/14852022942?pr=53 and I failed to demo it the last week.

It's a workaround for now. The best fix it work with Vega to fix their CLI. I'm not sure it's a priority at the moment since we have quick workaround if needed, JS version of Vega seems to work fine, and I'm not sure for the long term future of Vega in the project (tbh we need to migrate I think to something else after all as soon as we have more time and resources). 