### PR TITLE
fix(example-get-started): avoid inf and nans in prc plot output

### DIFF
--- a/example-get-started/code/.github/workflows/cml.yaml
+++ b/example-get-started/code/.github/workflows/cml.yaml
@@ -12,6 +12,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 2
+      # Needed for https://github.com/iterative/example-repos-dev/issues/225
+      - name: Installs JSON5
+        run: npm install -g json5
       - name: Generate metrics report
         env:
           REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -25,15 +28,15 @@ jobs:
           fi
 
           dvc plots diff $PREVIOUS_REF workspace \
-            --show-vega --targets ROC > vega.json
+            --show-vega --targets ROC | json5 > vega.json
           vl2svg vega.json roc.svg
 
           dvc plots diff $PREVIOUS_REF workspace \
-            --show-vega --targets Precision-Recall > vega.json
+            --show-vega --targets Precision-Recall | json5 > vega.json
           vl2svg vega.json prc.svg
 
           dvc plots diff $PREVIOUS_REF workspace \
-            --show-vega --targets Confusion-Matrix > vega.json
+            --show-vega --targets Confusion-Matrix | json5 > vega.json
           vl2svg vega.json confusion.svg
 
           dvc pull eval/importance.png


### PR DESCRIPTION
Fixes https://github.com/iterative/example-repos-dev/issues/225

`json5` CLI replaces `Infinity` and other non-JSON.parse values with `null` which is "fine" with Vega.

Since we have PRs broken in the example repo https://github.com/iterative/example-get-started/actions/runs/5484365547/job/14852022942?pr=53 and I failed to demo it the last week.

It's a workaround for now. The best fix it work with Vega to fix their CLI - https://github.com/vega/vega-lite/issues/9026. I'm not sure it's a priority at the moment since we have quick workaround if needed, JS version of Vega seems to work fine, and I'm not sure for the long term future of Vega in the project (tbh we need to migrate I think to something else after all as soon as we have more time and resources).