### PR TITLE
add gha to test example-get-started

### DIFF
--- a/.github/workflows/example-get-started-test.yaml
+++ b/.github/workflows/example-get-started-test.yaml
@@ -1,0 +1,24 @@
+name: example-get-started test
+on: 
+  push:
+    paths:
+      - example-get-started/**
+  workflow_dispatch:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+    - uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-region: us-east-2
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: 43200
+    - name: Generate repo
+      run: ./generate.sh

--- a/.github/workflows/example-get-started-test.yaml
+++ b/.github/workflows/example-get-started-test.yaml
@@ -21,4 +21,6 @@ jobs:
         role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 43200
     - name: Generate repo
-      run: ./generate.sh
+      run: |
+        cd example-get-started
+        ./generate.sh

--- a/.github/workflows/example-get-started-test.yaml
+++ b/.github/workflows/example-get-started-test.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    environment: aws
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3


### PR DESCRIPTION
Step 1 in trying to setup some automation of this repo. This PR adds only an action to test that `example-get-started/generate.sh` runs successfully when changes to `example-get-started` are pushed. Next would be to make another action to do all the deployment steps when a PR is merged, and then we could add similar actions for `example-get-started-experiments`.