### PR TITLE
initial gha to test example-get-started-experiments

### DIFF
--- a/.github/workflows/example-get-started-experiments-test.yaml
+++ b/.github/workflows/example-get-started-experiments-test.yaml
@@ -25,12 +25,12 @@ jobs:
         run: |
           cml runner launch --single \
             --labels=cml \
-            --cloud=${{ inputs.cloud || 'aws' }} \
-            --cloud-region=${{ inputs.region || 'us-east' }} \
-            --cloud-hdd-size=${{ inputs.storage || '40' }} \
-            --cloud-type=${{ inputs.type || 'g5.2xlarge' }} \
-            --idle-timeout=${{ inputs.timeout || '3600' }} \
-             ${{ inputs.spot && '--cloud-spot' }}
+            --cloud=aws \
+            --cloud-region=us-east \
+            --cloud-hdd-size=40 \
+            --cloud-type=g5.2xlarge
+            --idle-timeout=3600 \
+            --cloud-spot
   test:
     needs: deploy-runner
     runs-on: [ self-hosted, cml ]

--- a/.github/workflows/example-get-started-experiments-test.yaml
+++ b/.github/workflows/example-get-started-experiments-test.yaml
@@ -1,0 +1,60 @@
+name: example-get-started-experiments test
+on: 
+  push:
+    paths:
+      - example-get-started-experiments/**
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  deploy-runner:
+    environment: aws
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: iterative/setup-cml@v1
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-2
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-duration-seconds: 43200
+      - name: Create Runner
+        env:
+          REPO_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          cml runner launch --single \
+            --labels=cml \
+            --cloud=${{ inputs.cloud || 'aws' }} \
+            --cloud-region=${{ inputs.region || 'us-east' }} \
+            --cloud-hdd-size=${{ inputs.storage || '40' }} \
+            --cloud-type=${{ inputs.type || 'g5.2xlarge' }} \
+            --idle-timeout=${{ inputs.timeout || '3600' }} \
+             ${{ inputs.spot && '--cloud-spot' }}
+  test:
+    needs: deploy-runner
+    runs-on: [ self-hosted, cml ]
+    environment: aws
+    container:
+      image: iterativeai/cml:0-dvc2-base1-gpu
+      options: --gpus all --ipc host
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+    - uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-region: us-east-2
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: 43200
+    - name: Generate repo
+      env:
+        REPO_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      run: |
+        pip install virtualenv
+        cd example-get-started-experiments
+        ./generate.sh


### PR DESCRIPTION
Similar to the recent action added to generate `example-get-started`, this does the same for `example-get-started-experiments`. It also uses the cml runner to launch a self-hosted instance for training.

This requires a `PERSONAL_ACCESS_TOKEN` be added to the repo. @daavoo @shcheklein How did we set up the token for `example-get-started-experiments`? Can/should we use the same here?