### PR TITLE
example-get-started: remove unneeded eval customization stage

### DIFF
--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -310,15 +310,6 @@ EOF
       python src/evaluate.py model.pkl data/features
   fi
 
-  dvc repro
-  git add .gitignore dvc.yaml dvc.lock eval
-  tick
-  git commit -am "${COMMIT_PREFIX}Create evaluation stage"
-  create_tag "8-dvclive-eval${GIT_TAG_SUFFIX}" "DVCLive evaluation stage created."
-  dvc push
-
-  sed -e 's/Live(\(.*\))/(\1, dvcyaml=False)/' src/evaluate.py
-
   echo "metrics:
 - eval/metrics.json
 plots:
@@ -341,11 +332,12 @@ plots:
       eval/plots/sklearn/prc/train.json: precision
       eval/plots/sklearn/prc/test.json: precision
 - eval/plots/images/importance.png" >> dvc.yaml
+
   dvc repro
   git add .gitignore dvc.yaml dvc.lock eval
   tick
-  git commit -am "${COMMIT_PREFIX}Customize evaluation plots"
-  create_tag "9-custom-eval${GIT_TAG_SUFFIX}" "Custom evaluation stage created."
+  git commit -am "${COMMIT_PREFIX}Create evaluation stage"
+  create_tag "8-dvclive-eval${GIT_TAG_SUFFIX}" "DVCLive evaluation stage created."
   create_tag "baseline-experiment${GIT_TAG_SUFFIX}" "Baseline experiment evaluation"
   if [ $OPT_TAG_MODELS == "true" ]; then
     gto register "${GTO_PREFIX}${OPT_MODEL_NAME}" --version v1.0.0
@@ -360,7 +352,7 @@ plots:
   dvc repro train
   tick
   git commit -am "${COMMIT_PREFIX}Reproduce model using bigrams"
-  create_tag "10-bigrams-model${GIT_TAG_SUFFIX}" "Model retrained using bigrams."
+  create_tag "9-bigrams-model${GIT_TAG_SUFFIX}" "Model retrained using bigrams."
   if [ $OPT_TAG_MODELS == "true" ]; then
     gto register "${GTO_PREFIX}${OPT_MODEL_NAME}" --version v1.1.0
     gto assign "${GTO_PREFIX}${OPT_MODEL_NAME}" --version v1.1.0 --stage stage
@@ -372,7 +364,7 @@ plots:
   tick
   git commit -am "${COMMIT_PREFIX}Evaluate bigrams model"
   create_tag "bigrams-experiment${GIT_TAG_SUFFIX}" "Bigrams experiment evaluation"
-  create_tag "11-bigrams-experiment${GIT_TAG_SUFFIX}" "Evaluated bigrams model."
+  create_tag "10-bigrams-experiment${GIT_TAG_SUFFIX}" "Evaluated bigrams model."
   if [ $OPT_TAG_MODELS == "true" ]; then
     gto register "${GTO_PREFIX}${OPT_MODEL_NAME}" --version v1.2.0
     gto assign "${GTO_PREFIX}${OPT_MODEL_NAME}" --version v1.2.0 --stage dev
@@ -408,7 +400,7 @@ if [ $OPT_NON_DVC == 'false' ] && [ $OPT_BRANCHES == 'true' ]; then
   tick
   git commit -am "${COMMIT_PREFIX}Run experiments tuning random forest params"
   create_tag "random-forest-experiments${GIT_TAG_SUFFIX}" "Run experiments to tune random forest params"
-  create_tag "12-random-forest-experiments${GIT_TAG_SUFFIX}" "Tuned random forest classifier."
+  create_tag "11-random-forest-experiments${GIT_TAG_SUFFIX}" "Tuned random forest classifier."
   dvc push
 
   git checkout main


### PR DESCRIPTION
I [recently](https://github.com/iterative/example-repos-dev/pull/238) added an extra commit to convert from auto-dvclive configuration to custom plots configuration. However, I missed that since we never call `Live. end()` or `Live.make_dvcyaml()` in this repo, we never generate the auto config. In this PR, I revert back to having a single eval commit.