### PR TITLE
fix(example-get-started): cache images, fix reports action

### DIFF
--- a/example-get-started/code/.github/workflows/cml.yaml
+++ b/example-get-started/code/.github/workflows/cml.yaml
@@ -39,12 +39,12 @@ jobs:
             --show-vega --targets Confusion-Matrix | json5 > vega.json
           vl2svg vega.json confusion.svg
 
-          dvc pull eval/importance.png
-          cp eval/importance.png importance_workspace.png
+          dvc pull eval/plots/images
+          cp eval/plots/images/importance.png importance_workspace.png
 
           git checkout $PREVIOUS_REF -- dvc.lock
-          dvc pull eval/importance.png
-          cp eval/importance.png importance_previous.png
+          dvc pull eval/plots/images
+          cp eval/plots/images/importance.png importance_previous.png
 
           dvc_report=$(dvc exp diff $PREVIOUS_REF --md)
 

--- a/example-get-started/code/README.md
+++ b/example-get-started/code/README.md
@@ -1,4 +1,4 @@
-[![DVC](https://img.shields.io/badge/-Open_in_Studio-grey.svg?style=flat-square&logo=dvc)](https://studio.iterative.ai/team/Iterative/views/example-get-started-zde16i6c4g) [![DVC-metrics](https://img.shields.io/badge/dynamic/json?style=flat-square&colorA=grey&colorB=F46737&label=Average%20Precision&url=https://github.com/iterative/example-get-started/raw/main/eval/live/metrics.json&query=avg_prec.test)](https://github.com/iterative/example-get-started/raw/main/eval/live/metrics.json)
+[![DVC](https://img.shields.io/badge/-Open_in_Studio-grey.svg?style=flat-square&logo=dvc)](https://studio.iterative.ai/team/Iterative/views/example-get-started-zde16i6c4g) [![DVC-metrics](https://img.shields.io/badge/dynamic/json?style=flat-square&colorA=grey&colorB=F46737&label=Average%20Precision&url=https://github.com/iterative/example-get-started/raw/main/eval/metrics.json&query=avg_prec.test)](https://github.com/iterative/example-get-started/raw/main/eval/metrics.json)
 
 # DVC Get Started
 

--- a/example-get-started/code/src/evaluate.py
+++ b/example-get-started/code/src/evaluate.py
@@ -100,13 +100,14 @@ def main():
         test, _ = pickle.load(fd)
 
     # Evaluate train and test datasets.
-    live = Live(EVAL_PATH)
-    evaluate(model, train, "train", live, save_path=EVAL_PATH)
-    evaluate(model, test, "test", live, save_path=EVAL_PATH)
-    live.make_summary()
+    with Live(EVAL_PATH, cache_images=True, dvcyaml=False) as live:
+        evaluate(model, train, "train", live, save_path=EVAL_PATH)
+        evaluate(model, test, "test", live, save_path=EVAL_PATH)
 
-    # Dump feature importance plot.
-    save_importance_plot(live, model, feature_names)
+        live.make_summary()
+
+        # Dump feature importance plot.
+        save_importance_plot(live, model, feature_names)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes (bumped today into this):

<img width="706" alt="Screenshot 2023-08-31 at 5 12 46 PM" src="https://github.com/iterative/example-repos-dev/assets/3659196/a7c96d25-006c-4a74-9f06-823b4b72cd3c">

<img width="939" alt="Screenshot 2023-08-31 at 5 12 27 PM" src="https://github.com/iterative/example-repos-dev/assets/3659196/5f12153d-261e-4ad9-8a3f-729a4a086dcf">

It's better to cache images I think. It creates a stronger example on how things could be managed (I got a question today if images could be cached or not). It's better since we cover a bit more advanced scenario + probably ppl will use it this way.