### PR TITLE
add gha to deploy example-get-started

### DIFF
--- a/.github/workflows/example-get-started-deploy.yaml
+++ b/.github/workflows/example-get-started-deploy.yaml
@@ -1,0 +1,61 @@
+name: example-get-started deploy
+on: 
+  push:
+    paths:
+      - example-get-started/**
+    branches:
+      - master
+  workflow_dispatch:
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment: aws
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+    - uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-region: us-east-2
+        role-to-assume: ${{ vars.AWS_SANDBOX_ROLE }}
+        role-duration-seconds: 43200
+    - uses: iterative/setup-dvc@v1
+    - name: Generate repo
+      run: |
+        pip install virtualenv
+        cd example-get-started
+        ./generate.sh true
+    - name: Deploy repo
+      env:
+        REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # add remote
+        cd build/example-get-started
+        git remote add origin git@github.com:iterative/example-get-started.git
+        # close open PRs
+        gh pr close try-large-dataset
+        gh pr close tune-hyperparams
+        # force push branches
+        git push --force origin main
+        git push --force origin try-large-dataset
+        git push --force origin tune-hyperparams
+        # we push git tags one by one for Studio to receive webhooks:
+        git tag --sort=creatordate | xargs -n 1 git push --force origin
+        # push exp refs
+        dvc exp remove -A -g origin
+        dvc exp push origin -A
+        # create PRs
+        gh pr create -t "Try 40K dataset (4x data)" \
+           -b "We are trying here a large dataset, since the smaller one looks unstable" \
+           -B main -H try-large-dataset
+        gh pr create -t "Run experiments tuning random forest params" \
+           -b "Better RF split and number of estimators based on small grid search." \
+           -B main -H tune-hyperparams

--- a/.github/workflows/example-get-started-deploy.yaml
+++ b/.github/workflows/example-get-started-deploy.yaml
@@ -43,6 +43,8 @@ jobs:
         # close open PRs
         gh pr close try-large-dataset
         gh pr close tune-hyperparams
+        # drop existing refs
+        git ls-remote origin | awk '{print $2}' | xargs -n 1 git push --delete origin || true
         # force push branches
         git push --force origin main
         git push --force origin try-large-dataset
@@ -50,7 +52,6 @@ jobs:
         # we push git tags one by one for Studio to receive webhooks:
         git tag --sort=creatordate | xargs -n 1 git push --force origin
         # push exp refs
-        dvc exp remove -A -g origin
         dvc exp push origin -A
         # create PRs
         gh pr create -t "Try 40K dataset (4x data)" \

--- a/.github/workflows/example-get-started-test.yaml
+++ b/.github/workflows/example-get-started-test.yaml
@@ -4,6 +4,8 @@ on:
     paths:
       - example-get-started/**
   workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * 1'
 permissions:
   contents: read
   id-token: write

--- a/README.md
+++ b/README.md
@@ -40,8 +40,14 @@ $ ./deploy.sh
 
 ### example-get-started
 
-You only directly need `generate.sh`. `deploy.sh` is a helper script run within
-`generate.sh`.
+There are 2 GitHub Actions set up to test and deploy the project:
+
+- [test](.github/workflows/example-get-started-test.yaml)
+- [deploy](.github/workflows/example-get-started-deploy.yaml)
+
+These will automatically test and deploy the project. If you need to run the project
+locally/manually, you only directly need `generate.sh`. `deploy.sh` is a helper script
+run within `generate.sh`.
 
 - `generate.sh`: Generates the `example-get-started` DVC project from
   scratch. 

--- a/example-get-started/README.md
+++ b/example-get-started/README.md
@@ -24,10 +24,10 @@ For the basic use case (docs and Studio demo), use the command below.
 ```
 
 If change source code, to publish it on S3 (needed for the get started tutorial)
-pass `true` to the command. It's needed when you ready to publish it.
+pass `prod` to the command. It's needed when you ready to publish it.
 
 ```shell
-./generate.sh true
+./generate.sh prod
 ```
 
 The repo generated in `build/example-get-started` is intended to be published on


### PR DESCRIPTION
Adds a workflow to auto deploy on any push to master. Unfortunately, according to https://github.com/orgs/community/discussions/25746, it looks like I can't try it until it gets merged to master first, so I'm opening the PR to merge and expecting to follow up after I can try it and debug.

After I get it working for this repo, I'll plan to do the same for example-get-started-experiments.