### PR TITLE
Drop acl from s3 upload

### DIFF
--- a/.github/workflows/example-get-started-deploy.yaml
+++ b/.github/workflows/example-get-started-deploy.yaml
@@ -29,7 +29,7 @@ jobs:
       run: |
         pip install virtualenv
         cd example-get-started
-        ./generate.sh true
+        ./generate.sh prod
     - name: Deploy repo
       env:
         GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/example-get-started/deploy.sh
+++ b/example-get-started/deploy.sh
@@ -20,7 +20,7 @@ popd
 mv $PACKAGE_DIR/$PACKAGE .
 if [ $PROD == 'prod' ]; then
 
-    aws s3 cp --acl public-read $PACKAGE s3://dvc-public/code/get-started/$PACKAGE
+    aws s3 cp $PACKAGE s3://dvc-public/code/get-started/$PACKAGE
 
     # Sanity check
     wget https://code.dvc.org/get-started/$PACKAGE -O $TEST_PACKAGE


### PR DESCRIPTION
Per https://github.com/iterative/example-repos-dev/actions/runs/6433803421/job/17471645914#step:6:931, this was causing the deployment workflow to fail. I think it shouldn't be needed since the acl is already set for that path. I was able to deploy without it and download the updated code.