### PR TITLE
experiments: split dvclive outputs by train/eval

### DIFF
--- a/example-get-started-experiments/generate.sh
+++ b/example-get-started-experiments/generate.sh
@@ -112,12 +112,12 @@ dvc stage add -n train \
   -p base,train \
   -d src/train.py -d data/train_data \
   -o models/model.pkl -o models/model.pth \
-  python src/train.py
+  -o results/train python src/train.py
 
 dvc stage add -n evaluate \
   -p base,evaluate \
   -d src/evaluate.py -d models/model.pkl -d data/test_data \
-  -o results python src/evaluate.py
+  -o results/evaluate python src/evaluate.py
 
 dvc stage add -n sagemaker \
   -d models/model.pth -o model.tar.gz \


### PR DESCRIPTION
Fixes missing training metrics. Before this PR, we are only capturing `results` as an output of the evaluate stage, but `results/train` is actually generated during the train stage, and then is getting deleted by dvc during the evaluate stage, dropping the training metrics. This PR fixes it by granularly tracking `results/train` as an output of the train stage and `results/evaluate` as an output of the `evaluate` stage.