### PR TITLE
Sagemaker deployment - same role to assume and for deployment

### DIFF
--- a/example-get-started-experiments/code/.github/workflows/deploy-model.yml
+++ b/example-get-started-experiments/code/.github/workflows/deploy-model.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 0
     - name: "Parse GTO tag"
       id: gto
-      uses: iterative/gto-action@14723404a00bb0c1e759c02ffcd24279df5815c2
+      uses: iterative/gto-action@v2
     outputs:
       event: ${{ steps.gto.outputs.event }}
       name: ${{ steps.gto.outputs.name }}
@@ -45,7 +45,7 @@ jobs:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         aws-region: us-east-2
-        role-to-assume: ${{ vars.AWS_SAGEMAKER_ROLE }}
+        role-to-assume: ${{ vars.AWS_SANDBOX_ROLE }}
         role-duration-seconds: 43200
 
     - name: Set up Python
@@ -66,4 +66,4 @@ jobs:
         --stage ${{ needs.parse.outputs.stage }} \
         --version ${{ needs.parse.outputs.version }} \
         --model_data $MODEL_DATA \
-        --role ${{ vars.AWS_SAGEMAKER_ROLE }}
+        --role ${{ vars.AWS_SANDBOX_ROLE }}

--- a/example-get-started-experiments/code/.github/workflows/deploy-model.yml
+++ b/example-get-started-experiments/code/.github/workflows/deploy-model.yml
@@ -66,4 +66,4 @@ jobs:
         --stage ${{ needs.parse.outputs.stage }} \
         --version ${{ needs.parse.outputs.version }} \
         --model_data $MODEL_DATA \
-        --role ${{ vars.AWS_SANDBOX_ROLE }}
+        --role ${{ vars.AWS_SAGEMAKER_ROLE }}


### PR DESCRIPTION
If I understand the logic correctly, we want to use the AWS_SAGEMAKER_ROLE in both the credentials action and in the deploy_model script.

In fact at this point both of these `vars` contain the same role I think (though I don't have the rights to see secrets and variables in this repo).

But this way it is a bit cleaner, especially if someone wants to replicate the workflow.