### PR TITLE
feat(example-get-started): add an option for GDrive remote

### DIFF
--- a/example-get-started/README.md
+++ b/example-get-started/README.md
@@ -123,7 +123,7 @@ repositories and/or use different remote types.
   branches (bigger dataset, etc). It supports nested repos - branch names will
   have prefixes or suffixes to distinguish them.
 - `OPT_REMOTE="public-s3"` - (default `private-s3`). Other options: `public-s3`,
-  `private-http`, `private-ssh`, etc.
+  `private-http`, `private-ssh`, `private-gdrive`, etc.
 - `OPT_DVC_TRACKED_METRICS='true'` - (default `true`). Either we should use
   DVC to also track all metric and plot files (e.g. to test that Studio can get
   plots from the remote storage).

--- a/example-get-started/generate.sh
+++ b/example-get-started/generate.sh
@@ -63,6 +63,17 @@ init_remote_storage() {
     dvc remote add -f -d $OPT_REMOTE https://remote.dvc.org/get-started
   fi
 
+  if [ $OPT_REMOTE == 'private-gdrive' ]; then
+    # This corresponds to the Iterative shared GDrive disk.
+    dvc remote add -f -d $OPT_REMOTE gdrive://1x2tUWiCqcHxmUli7BP6qOrrlmp-12DYY
+    # In Studio we have to use a custom app for GDrive. This one is created in
+    # the pydrive-test project and in Studio we provide service account credentials.
+    # When testing in Studio get a service credentials JSON file from the Google
+    # Cloud Console.
+    dvc remote modify $OPT_REMOTE gdrive_client_id "47794215776-cd9ssb6a4vv5otkq6n0iadpgc4efgjb1.apps.googleusercontent.com"
+    dvc remote modify $OPT_REMOTE gdrive_client_secret 'i2gerGA7uBjZbR08HqSOSt9Z'
+  fi
+
   if [ $OPT_REMOTE == 'private-s3' ]; then
     dvc remote add -f -d $OPT_REMOTE s3://dvc-private/remote/get-started
   fi


### PR DESCRIPTION
Adds GDrive remote option to test Studio. I've updated the fixture here: https://github.com/iterative/example-get-started-gdrive-private-fixture/