### PR TITLE
experiments: use 3.0 cache for pool data

### DIFF
--- a/example-get-started-experiments/code/data/pool_data.dvc
+++ b/example-get-started-experiments/code/data/pool_data.dvc
@@ -3,3 +3,4 @@ outs:
   size: 18999874
   nfiles: 183
   path: pool_data
+  hash: md5


### PR DESCRIPTION
Somehow we never updated the pool data to the 3.0 cache (the stack overflow data in the other repo is already updated).