### PR TITLE
drop GIT_COMMITTER_DATE

### DIFF
--- a/example-get-started-experiments/generate.sh
+++ b/example-get-started-experiments/generate.sh
@@ -20,11 +20,9 @@ STEP_TIME=100000
 BEGIN_TIME=$(( $(date +%s) - ( ${TOTAL_TAGS} * ${STEP_TIME}) ))
 export TAG_TIME=${BEGIN_TIME}
 export GIT_AUTHOR_DATE="${TAG_TIME} +0000"
-export GIT_COMMITTER_DATE="${TAG_TIME} +0000"
 tick(){
   export TAG_TIME=$(( ${TAG_TIME} + ${STEP_TIME} ))
   export GIT_AUTHOR_DATE="${TAG_TIME} +0000"
-  export GIT_COMMITTER_DATE="${TAG_TIME} +0000"
 }
 
 export GIT_AUTHOR_NAME="Alex Kim"


### PR DESCRIPTION
Fixes https://github.com/iterative/studio/issues/8951.

It looks like this must be a bug in dulwich or scmrepo. When `GIT_COMMITTER_DATE` is set, it causes `GIT_COMMITTER_NAME` to be ignored. This is not the case for CLI Git, and the dates and formats appear valid. I don't see a need for this var anywhere (`GIT_AUTHOR_DATE` seems to be enough for the commits), so it looks easiest to drop this.